### PR TITLE
fix(package.json,typescript config): fix filepath in scripts & tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,9 +66,9 @@
     "compile": "npx hardhat compile",
     "test": "npx hardhat test",
     "test:gas": "REPORT_GAS=true npx hardhat test",
-    "deploy:localhost": "npx hardhat run scripts/deploy.js --network localhost",
-    "upgrade:localhost": "npx hardhat run scripts/upgradeContract/upgradeState.js --network localhost",
-    "deploy:ropsten": "npx hardhat run scripts/deploy.js --network ropsten",
+    "deploy:localhost": "npx hardhat run scripts/deploy.ts --network localhost",
+    "upgrade:localhost": "npx hardhat run scripts/upgradeContract/upgradeState.ts --network localhost",
+    "deploy:ropsten": "npx hardhat run scripts/deploy.ts --network ropsten",
     "verify:ropsten": "npx hardhat run scripts/verifyEtherescan.js --network ropsten"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,5 @@
     "noImplicitAny": false
   },
   "include": ["./scripts", "./test", "./typechain"],
-  "files": ["hardhat.config.js"]
+  "files": ["hardhat.config.ts"]
 }


### PR DESCRIPTION
Some files from the project have been migrated to typescript but their corresponding filepath in scripts of `package.json` and tsconfig have not been updated causing the project scripts to fail. This PR fixes resolves this.