### PR TITLE
Onchain identity: fix ID calculation

### DIFF
--- a/contracts/lib/GenesisUtils.sol
+++ b/contracts/lib/GenesisUtils.sol
@@ -80,13 +80,8 @@ library GenesisUtils {
      */
     function isGenesisState(uint256 id, uint256 idState) internal pure returns (bool)
     {
-        bytes memory idBytes = int256ToBytes(id);
-
-        bytes memory idType = BytesLib.slice(idBytes, idBytes.length - 31, 2);
-
-        // TODO: maybe we can do just bytes2(idBytes) - should take first 2 bytes
-        uint256 computedId = calcIdFromGenesisState(bytes2(idType), idState);
-
+        bytes2 idType = bytes2(int256ToBytes(reverse(id)));
+        uint256 computedId = calcIdFromGenesisState(idType, idState);
         return id == computedId;
     }
 

--- a/contracts/lib/GenesisUtils.sol
+++ b/contracts/lib/GenesisUtils.sol
@@ -133,15 +133,10 @@ library GenesisUtils {
      */
     function calcOnchainIdFromAddress(bytes2 idType, address caller) internal pure returns (uint256)
     {
-        // shift address left 7 bytes, because calcIdFromGenesisState cuts last 5 bytes after swapping endianness:
-        // 32 bytes of uint256 - 20bytes of address - 5 bytes cut by calcIdFromGenesisState == 7 bytes shift
-        uint256 addrShifted = reverse(uint256(uint160(caller))<<56);
+        uint256 addr = uint256(uint160(caller));
 
         // shift right 1 byte, because id is 31 byte long and reverse does it for 32bytes
-        // TODO: check that reverse is needed!!!!
-        return reverse(calcIdFromGenesisState(idType, addrShifted))>>8;
-
-        //return calcIdFromGenesisState(idType, addrShifted);
+        return reverse(calcIdFromGenesisState(idType, addr))>>8;
     }
 
     /**

--- a/contracts/lib/GenesisUtils.sol
+++ b/contracts/lib/GenesisUtils.sol
@@ -66,23 +66,6 @@ library GenesisUtils {
     }
 
     /**
-     * @dev bytesToHexString
-     */
-    function bytesToHexString(bytes memory buffer) internal pure returns (string memory) {
-        // Fixed buffer size for hexadecimal convertion
-        bytes memory converted = new bytes(buffer.length * 2);
-
-        bytes memory _base = "0123456789abcdef";
-
-        for (uint256 i = 0; i < buffer.length; i++) {
-            converted[i * 2] = _base[uint8(buffer[i]) / _base.length];
-            converted[i * 2 + 1] = _base[uint8(buffer[i]) % _base.length];
-        }
-
-        return string(abi.encodePacked("0x", converted));
-    }
-
-    /**
      * @dev compareStrings
      */
     function compareStrings(string memory a, string memory b) internal pure returns (bool) {
@@ -125,7 +108,10 @@ library GenesisUtils {
         bytes memory idBytes = BytesLib.concat(beforeChecksum, checkSumBytes);
         require(idBytes.length == 31, "idBytes requires 31 length array");
 
-        return uint256(uint248(bytes31(idBytes)));
+        return reverse(toUint256(idBytes));
+
+        // shift right 1 byte, because id is 31 byte long and reverse does it for 32bytes
+        //return reverse(uint256(uint248(bytes31(idBytes))))>>8;
     }
 
     /**
@@ -135,8 +121,7 @@ library GenesisUtils {
     {
         uint256 addr = uint256(uint160(caller));
 
-        // shift right 1 byte, because id is 31 byte long and reverse does it for 32bytes
-        return reverse(calcIdFromGenesisState(idType, addr))>>8;
+        return calcIdFromGenesisState(idType, addr);
     }
 
     /**

--- a/contracts/test/GenesisUtilsWrapper.sol
+++ b/contracts/test/GenesisUtilsWrapper.sol
@@ -7,4 +7,10 @@ contract GenesisUtilsWrapper {
     function isGenesisState(uint256 id, uint256 idState) public pure returns (bool) {
         return GenesisUtils.isGenesisState(id, idState);
     }
+    function calcIdFromGenesisState(bytes2 idType, uint256 idState) public pure returns (uint256) {
+        return GenesisUtils.calcIdFromGenesisState(idType, idState);
+    }
+    function calcOnchainIdFromAddress(bytes2 idType, address caller) public pure returns (uint256) {
+        return GenesisUtils.calcOnchainIdFromAddress(idType, caller);
+    }
 }

--- a/helpers/OnchainIdentityDeployHelper.ts
+++ b/helpers/OnchainIdentityDeployHelper.ts
@@ -9,7 +9,7 @@ export class OnchainIdentityDeployHelper {
   ) {}
 
   static async initialize(
-    signers: SignerWithAddress | null = null,
+    signers: SignerWithAddress[] | null = null,
     enableLogging = false
   ): Promise<OnchainIdentityDeployHelper> {
     let sgrs;

--- a/helpers/StateDeployHelper.ts
+++ b/helpers/StateDeployHelper.ts
@@ -12,7 +12,7 @@ export class StateDeployHelper {
   ) {}
 
   static async initialize(
-    signers: SignerWithAddress | null = null,
+    signers: SignerWithAddress[] | null = null,
     enableLogging = false
   ): Promise<StateDeployHelper> {
     let sgrs;

--- a/test/genesisUtils/genesisUtils.test.ts
+++ b/test/genesisUtils/genesisUtils.test.ts
@@ -1,95 +1,116 @@
 import { deployGenesisUtilsWrapper } from "../utils/deploy-utils";
 import { expect } from "chai";
 
+let guWrpr;
+const testVectors = [
+  { // (Iden3, NoChain, NoNetwork)
+    id: '0x01000000000000000000000000000000000000000000000000000000131400',
+    idType: '0x0100',
+    genIdState:    '0x13',
+    nonGenIdState: '0x12'
+  },
+  { // (PolygonId, NoChain, NoNetwork)
+    id: '0x02000000000000000000000000000000000000000000000000000000131500',
+    idType: '0x0200',
+    genIdState:    '0x13',
+    nonGenIdState: '0x14'
+  },
+  { // (PolygonId, Polygon, Main)
+    id: '0x02110000000000000000000000000000000000000000000000000000132600',
+    idType: '0x0211',
+    genIdState:    '0x13',
+    nonGenIdState: '0x25'
+  },
+  { // (PolygonId, Polygon, Mumbai)
+    id: '0x02120000000000000000000000000000000000000000000000000000132700',
+    idType: '0x0212',
+    genIdState:    '0x13',
+    nonGenIdState: '0x32'
+  },
+  {
+    id: '0x0112fe69563748453de004c140c247d5b3eed715e1640bf314b5bfa0109c0d',
+    idType: '0x0112',
+    genIdState:    '0xfe69563748453de004c140c247d5b3eed715e1640bf314b5bfa010',
+    nonGenIdState: '0xfe69563748453de004c140c147d5b3eed715e1640bf314b5bfa010'
+  },
+  {
+    // generated in go-iden3-core
+    id: '0x0112fe69563748453de004c140c247d5b3eed715e1640bf314b5bfa0109c0d',
+    idType: '0x0112',
+    genIdState:    '0x1a2817575efe69563748453de004c140c247d5b3eed715e1640bf314b5bfa010',
+    nonGenIdState: '0x1a2817575efe69563748453de004c140c247d5b3eed715e1640bf314b5bfa011'
+  },
+  {
+    id: '0x0112fe69563748453de004c140c247d5b3eed715e1640bf314b5bfa0109c0d',
+    idType: '0x0112',
+    // only lower 27 bytes are used, so first 5 bytes do not influence the result
+    genIdState:    '0x0000000000fe69563748453de004c140c247d5b3eed715e1640bf314b5bfa010',
+    nonGenIdState: '0x0000000000fe69563748453de004c140c247d5b3eed715e1640bf314b5bfa011'
+  },
+  {
+    id: '0x0112fe69563748453de004c140c247d5b3eed715e1640bf314b5bfa0109c0d',
+    idType: '0x0112',
+    // only lower 27 bytes are used, so first 5 bytes do not influence the result
+    genIdState:    '0xfffffffffffe69563748453de004c140c247d5b3eed715e1640bf314b5bfa010',
+    nonGenIdState: '0xfffffffffffe69563748453de004c140c247d5b3eed715e1640bf314b5bfa011'
+  },
+  {
+    id: '0x0001c3e9254b0becbf3d7b01d0f562e417adb4c13d453544485c013f29d80b',
+    idType: '0x0001',
+    genIdState:    '0xc3e9254b0becbf3d7b01d0f562e417adb4c13d453544485c013f29',
+    nonGenIdState: '0xc3e9254b0becbf3d7b01d1f562e517adb3c13d453544485c013f29'
+  },
+  {
+    id: '0x011256791df9964673d9965def42a56e49c9b89964b7b4c2c5a897fcbf0a10',
+    idType: '0x0112',
+    genIdState:    '0x56791df9964673d9965def42a56e49c9b89964b7b4c2c5a897fcbf',
+    nonGenIdState: '0x56791df9964673d9965def42a56e49c9b89964b7b4c2c5a897fcaa'
+  },
+  {
+    id: '0x0000e026bb4afefadf93bd00644ad2139045a95edbf026e67c4f931812000e',
+    idType: '0x0000',
+    genIdState:    '0xe026bb4afefadf93bd00644ad2139045a95edbf026e67c4f931812',
+    nonGenIdState: '0xe126bb4afefadf93bd00644ad2139045a95edbf026e67c4f931812'
+  },
+  {
+    id: '0x0000d119a5c0b9fe1659620b8a635024d5ed0fed3cc9f5f20403a9ff48e40d',
+    idType: '0x0000',
+    genIdState:    '0xd119a5c0b9fe1659620b8a635024d5ed0fed3cc9f5f20403a9ff48',
+    nonGenIdState: '0xd219a5c0b9fe1669620b8a635024d5ed0fed3cc9f5f20403a9ff49'
+  },
+  {
+    id: '0x010056791df9964673d9965def42a56e49c9b89964b7b4c2c5a897fcbff80f',
+    idType: '0x0100',
+    genIdState:    '0x56791df9964673d9965def42a56e49c9b89964b7b4c2c5a897fcbf',
+    nonGenIdState: '0x76791df9964673d9965def42a56e49c9b89964b7b4c2c5a897fcbf'
+  },
+];
 
-describe("genesis state tests", function () {
-  let guWrpr;
+before(async () => {
+  guWrpr = await deployGenesisUtilsWrapper();
+});
 
-  before(async () => {
-    guWrpr = await deployGenesisUtilsWrapper();
-  });
+describe("generate ID from genesis state and idType", function () {
+    for (let i = 0; i < testVectors.length; i++) {
+      it("testVector: " + i, async () => {
+        const idResult = await guWrpr.calcIdFromGenesisState(testVectors[i].idType, testVectors[i].genIdState);
 
+        console.log(idResult);
 
-  it("check provided IDs in the genesis state", async () => {
-    const expectedResults = [
-      { // (Iden3, NoChain, NoNetwork)
-        id: '0x01000000000000000000000000000000000000000000000000000000131400',
-        genIdState:    '0x13',
-        nonGenIdState: '0x12'
-      },
-      { // (PolygonId, NoChain, NoNetwork)
-        id: '0x02000000000000000000000000000000000000000000000000000000131500',
-        genIdState:    '0x13',
-        nonGenIdState: '0x14'
-      },
-      { // (PolygonId, Polygon, Main)
-        id: '0x02110000000000000000000000000000000000000000000000000000132600',
-        genIdState:    '0x13',
-        nonGenIdState: '0x25'
-      },
-      { // (PolygonId, Polygon, Mumbai)
-        id: '0x02120000000000000000000000000000000000000000000000000000132700',
-        genIdState:    '0x13',
-        nonGenIdState: '0x32'
-      },
-      { 
-        id: '0x0112fe69563748453de004c140c247d5b3eed715e1640bf314b5bfa0109c0d',
-        genIdState:    '0xfe69563748453de004c140c247d5b3eed715e1640bf314b5bfa010',
-        nonGenIdState: '0xfe69563748453de004c140c147d5b3eed715e1640bf314b5bfa010'
-      },
-      {
-        // generated in go-iden3-core
-        id: '0x0112fe69563748453de004c140c247d5b3eed715e1640bf314b5bfa0109c0d',
-        genIdState:    '0x1a2817575efe69563748453de004c140c247d5b3eed715e1640bf314b5bfa010',
-        nonGenIdState: '0x1a2817575efe69563748453de004c140c247d5b3eed715e1640bf314b5bfa011'
-      },
-      {
-        id: '0x0112fe69563748453de004c140c247d5b3eed715e1640bf314b5bfa0109c0d',
-        // only lower 27 bytes are used, so first 5 bytes do not influence the result
-        genIdState:    '0x0000000000fe69563748453de004c140c247d5b3eed715e1640bf314b5bfa010',
-        nonGenIdState: '0x0000000000fe69563748453de004c140c247d5b3eed715e1640bf314b5bfa011'
-      },
-      {
-        id: '0x0112fe69563748453de004c140c247d5b3eed715e1640bf314b5bfa0109c0d',
-        // only lower 27 bytes are used, so first 5 bytes do not influence the result
-        genIdState:    '0xfffffffffffe69563748453de004c140c247d5b3eed715e1640bf314b5bfa010',
-        nonGenIdState: '0xfffffffffffe69563748453de004c140c247d5b3eed715e1640bf314b5bfa011'
-      },
-      {
-        id: '0x0001c3e9254b0becbf3d7b01d0f562e417adb4c13d453544485c013f29d80b',
-        genIdState:    '0xc3e9254b0becbf3d7b01d0f562e417adb4c13d453544485c013f29',
-        nonGenIdState: '0xc3e9254b0becbf3d7b01d1f562e517adb3c13d453544485c013f29'
-      },
-      { 
-        id: '0x011256791df9964673d9965def42a56e49c9b89964b7b4c2c5a897fcbf0a10',
-        genIdState:    '0x56791df9964673d9965def42a56e49c9b89964b7b4c2c5a897fcbf',
-        nonGenIdState: '0x56791df9964673d9965def42a56e49c9b89964b7b4c2c5a897fcaa'
-      },
-      { 
-        id: '0x0000e026bb4afefadf93bd00644ad2139045a95edbf026e67c4f931812000e',
-        genIdState:    '0xe026bb4afefadf93bd00644ad2139045a95edbf026e67c4f931812',
-        nonGenIdState: '0xe126bb4afefadf93bd00644ad2139045a95edbf026e67c4f931812'
-      },
-      { 
-        id: '0x0000d119a5c0b9fe1659620b8a635024d5ed0fed3cc9f5f20403a9ff48e40d',
-        genIdState:    '0xd119a5c0b9fe1659620b8a635024d5ed0fed3cc9f5f20403a9ff48',
-        nonGenIdState: '0xd219a5c0b9fe1669620b8a635024d5ed0fed3cc9f5f20403a9ff49'
-      },
-      { 
-        id: '0x010056791df9964673d9965def42a56e49c9b89964b7b4c2c5a897fcbff80f',
-        genIdState:    '0x56791df9964673d9965def42a56e49c9b89964b7b4c2c5a897fcbf',
-        nonGenIdState: '0x76791df9964673d9965def42a56e49c9b89964b7b4c2c5a897fcbf'
-      },
-    ];
-
-    for (let i = 0; i < expectedResults.length; i++) {
-      const genResult = await guWrpr.isGenesisState(expectedResults[i].id, expectedResults[i].genIdState);
-      await expect(genResult).to.be.equal(true);
-
-      const nonGenResult = await guWrpr.isGenesisState(expectedResults[i].id, expectedResults[i].nonGenIdState);
-      await expect(nonGenResult).to.be.equal(false);
+        await expect(idResult._hex).to.be.equal(testVectors[i].id);
+      });
     }
+});
 
-  });
- 
+describe("check provided IDs in the genesis state", function () {
+  for (let i = 0; i < testVectors.length; i++) {
+    it("testVector: " + i, async () => {
+      const genResult = await guWrpr.isGenesisState(testVectors[i].id, testVectors[i].genIdState);
+      await expect(genResult).to.be.true;
+
+      const nonGenResult = await guWrpr.isGenesisState(testVectors[i].id, testVectors[i].nonGenIdState);
+      await expect(nonGenResult).to.be.false;
+    });
+  }
+
 });

--- a/test/genesisUtils/genesisUtils.test.ts
+++ b/test/genesisUtils/genesisUtils.test.ts
@@ -4,82 +4,82 @@ import { expect } from "chai";
 let guWrpr;
 const testVectors = [
   { // (Iden3, NoChain, NoNetwork)
-    id: '0x01000000000000000000000000000000000000000000000000000000131400',
+    id: '0x00141300000000000000000000000000000000000000000000000000000001',
     idType: '0x0100',
     genIdState:    '0x13',
     nonGenIdState: '0x12'
   },
   { // (PolygonId, NoChain, NoNetwork)
-    id: '0x02000000000000000000000000000000000000000000000000000000131500',
+    id: '0x00151300000000000000000000000000000000000000000000000000000002',
     idType: '0x0200',
     genIdState:    '0x13',
     nonGenIdState: '0x14'
   },
   { // (PolygonId, Polygon, Main)
-    id: '0x02110000000000000000000000000000000000000000000000000000132600',
+    id: '0x00261300000000000000000000000000000000000000000000000000001102',
     idType: '0x0211',
     genIdState:    '0x13',
     nonGenIdState: '0x25'
   },
   { // (PolygonId, Polygon, Mumbai)
-    id: '0x02120000000000000000000000000000000000000000000000000000132700',
+    id: '0x00271300000000000000000000000000000000000000000000000000001202',
     idType: '0x0212',
     genIdState:    '0x13',
     nonGenIdState: '0x32'
   },
   {
-    id: '0x0112fe69563748453de004c140c247d5b3eed715e1640bf314b5bfa0109c0d',
+    id: '0x0d9c10a0bfb514f30b64e115d7eeb3d547c240c104e03d4548375669fe1201',
     idType: '0x0112',
     genIdState:    '0xfe69563748453de004c140c247d5b3eed715e1640bf314b5bfa010',
     nonGenIdState: '0xfe69563748453de004c140c147d5b3eed715e1640bf314b5bfa010'
   },
   {
     // generated in go-iden3-core
-    id: '0x0112fe69563748453de004c140c247d5b3eed715e1640bf314b5bfa0109c0d',
+    id: '0x0d9c10a0bfb514f30b64e115d7eeb3d547c240c104e03d4548375669fe1201',
     idType: '0x0112',
     genIdState:    '0x1a2817575efe69563748453de004c140c247d5b3eed715e1640bf314b5bfa010',
     nonGenIdState: '0x1a2817575efe69563748453de004c140c247d5b3eed715e1640bf314b5bfa011'
   },
   {
-    id: '0x0112fe69563748453de004c140c247d5b3eed715e1640bf314b5bfa0109c0d',
+    id: '0x0d9c10a0bfb514f30b64e115d7eeb3d547c240c104e03d4548375669fe1201',
     idType: '0x0112',
     // only lower 27 bytes are used, so first 5 bytes do not influence the result
     genIdState:    '0x0000000000fe69563748453de004c140c247d5b3eed715e1640bf314b5bfa010',
     nonGenIdState: '0x0000000000fe69563748453de004c140c247d5b3eed715e1640bf314b5bfa011'
   },
   {
-    id: '0x0112fe69563748453de004c140c247d5b3eed715e1640bf314b5bfa0109c0d',
+    id: '0x0d9c10a0bfb514f30b64e115d7eeb3d547c240c104e03d4548375669fe1201',
     idType: '0x0112',
     // only lower 27 bytes are used, so first 5 bytes do not influence the result
     genIdState:    '0xfffffffffffe69563748453de004c140c247d5b3eed715e1640bf314b5bfa010',
     nonGenIdState: '0xfffffffffffe69563748453de004c140c247d5b3eed715e1640bf314b5bfa011'
   },
   {
-    id: '0x0001c3e9254b0becbf3d7b01d0f562e417adb4c13d453544485c013f29d80b',
+    id: '0x0bd8293f015c484435453dc1b4ad17e462f5d0017b3dbfec0b4b25e9c30100',
     idType: '0x0001',
     genIdState:    '0xc3e9254b0becbf3d7b01d0f562e417adb4c13d453544485c013f29',
     nonGenIdState: '0xc3e9254b0becbf3d7b01d1f562e517adb3c13d453544485c013f29'
   },
   {
-    id: '0x011256791df9964673d9965def42a56e49c9b89964b7b4c2c5a897fcbf0a10',
+    id: '0x100abffc97a8c5c2b4b76499b8c9496ea542ef5d96d9734696f91d79561201',
     idType: '0x0112',
     genIdState:    '0x56791df9964673d9965def42a56e49c9b89964b7b4c2c5a897fcbf',
     nonGenIdState: '0x56791df9964673d9965def42a56e49c9b89964b7b4c2c5a897fcaa'
   },
   {
-    id: '0x0000e026bb4afefadf93bd00644ad2139045a95edbf026e67c4f931812000e',
+    id: '0x0e001218934f7ce626f0db5ea9459013d24a6400bd93dffafe4abb26e00000',
     idType: '0x0000',
     genIdState:    '0xe026bb4afefadf93bd00644ad2139045a95edbf026e67c4f931812',
     nonGenIdState: '0xe126bb4afefadf93bd00644ad2139045a95edbf026e67c4f931812'
   },
   {
-    id: '0x0000d119a5c0b9fe1659620b8a635024d5ed0fed3cc9f5f20403a9ff48e40d',
+    id: '0x0de448ffa90304f2f5c93ced0fedd52450638a0b625916feb9c0a519d10000',
     idType: '0x0000',
     genIdState:    '0xd119a5c0b9fe1659620b8a635024d5ed0fed3cc9f5f20403a9ff48',
     nonGenIdState: '0xd219a5c0b9fe1669620b8a635024d5ed0fed3cc9f5f20403a9ff49'
   },
   {
-    id: '0x010056791df9964673d9965def42a56e49c9b89964b7b4c2c5a897fcbff80f',
+    id: '0x0ff8bffc97a8c5c2b4b76499b8c9496ea542ef5d96d9734696f91d79560001',
     idType: '0x0100',
     genIdState:    '0x56791df9964673d9965def42a56e49c9b89964b7b4c2c5a897fcbf',
     nonGenIdState: '0x76791df9964673d9965def42a56e49c9b89964b7b4c2c5a897fcbf'
@@ -94,10 +94,7 @@ describe("generate ID from genesis state and idType", function () {
     for (let i = 0; i < testVectors.length; i++) {
       it("testVector: " + i, async () => {
         const idResult = await guWrpr.calcIdFromGenesisState(testVectors[i].idType, testVectors[i].genIdState);
-
-        console.log(idResult);
-
-        await expect(idResult._hex).to.be.equal(testVectors[i].id);
+        expect(BigInt(idResult)).to.be.equal(BigInt(testVectors[i].id));
       });
     }
 });
@@ -106,10 +103,10 @@ describe("check provided IDs in the genesis state", function () {
   for (let i = 0; i < testVectors.length; i++) {
     it("testVector: " + i, async () => {
       const genResult = await guWrpr.isGenesisState(testVectors[i].id, testVectors[i].genIdState);
-      await expect(genResult).to.be.true;
+      expect(genResult).to.be.true;
 
       const nonGenResult = await guWrpr.isGenesisState(testVectors[i].id, testVectors[i].nonGenIdState);
-      await expect(nonGenResult).to.be.false;
+      expect(nonGenResult).to.be.false;
     });
   }
 

--- a/test/onchain-identity/onchain-identity.test.ts
+++ b/test/onchain-identity/onchain-identity.test.ts
@@ -37,8 +37,11 @@ describe("Next tests reproduce identity life cycle", function() {
       console.log(identity.address);
 
       expect(id).to.be.equal(
-        19435317712562231673898250973778224014638392712618728138799088409679761922n
+        18148217572028590643859359173103611579212110941630801448409877263163593218n
       );
+
+      console.log(BigInt(id).toString(16));
+
     });
   });
 

--- a/test/onchain-identity/onchain-identity.test.ts
+++ b/test/onchain-identity/onchain-identity.test.ts
@@ -9,21 +9,23 @@ describe("Next tests reproduce identity life cycle", function() {
   let latestSavedState;
   let latestComputedState;
 
-  describe("create identity", function () {
-    it("deploy state and identity", async function () {
-      const stDeployHelper = await StateDeployHelper.initialize();
-      const deployHelper = await OnchainIdentityDeployHelper.initialize();
-      const stContracts = await stDeployHelper.deployStateV2();
-      const contracts = await deployHelper.deployIdentity(
+  before(async function () {
+    const stDeployHelper = await StateDeployHelper.initialize();
+    const deployHelper = await OnchainIdentityDeployHelper.initialize();
+    const stContracts = await stDeployHelper.deployStateV2();
+    const contracts = await deployHelper.deployIdentity(
         stContracts.state,
         stContracts.smtLib,
         stContracts.poseidon1,
         stContracts.poseidon2,
         stContracts.poseidon3,
         stContracts.poseidon4
-      );
-      identity = contracts.identity;
+    );
+    identity = contracts.identity;
+  });
 
+  describe("create identity", function () {
+    it("deploy state and identity", async function () {
       expect(await identity.getIsOldStateGenesis()).to.be.equal(
         true
       );
@@ -31,6 +33,9 @@ describe("Next tests reproduce identity life cycle", function() {
 
     it("validate identity's id", async function () {
       const id = await identity.getId();
+
+      console.log(identity.address);
+
       expect(id).to.be.equal(
         19435317712562231673898250973778224014638392712618728138799088409679761922n
       );

--- a/test/onchain-identity/onchain-identity.test.ts
+++ b/test/onchain-identity/onchain-identity.test.ts
@@ -1,4 +1,5 @@
 import { expect } from "chai";
+import { ethers, network } from "hardhat";
 import { OnchainIdentityDeployHelper } from "../../helpers/OnchainIdentityDeployHelper";
 import { StateDeployHelper } from "../../helpers/StateDeployHelper";
 
@@ -10,8 +11,19 @@ describe("Next tests reproduce identity life cycle", function() {
   let latestComputedState;
 
   before(async function () {
-    const stDeployHelper = await StateDeployHelper.initialize();
-    const deployHelper = await OnchainIdentityDeployHelper.initialize();
+    const signer = await ethers.getImpersonatedSigner("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+    await network.provider.send("hardhat_setBalance", [
+      "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      "0x1000000000000000000",
+    ]);
+
+    await network.provider.send("hardhat_setNonce", [
+      "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      "0xffffffff0000"
+    ]);
+
+    const stDeployHelper = await StateDeployHelper.initialize([signer]);
+    const deployHelper = await OnchainIdentityDeployHelper.initialize([signer]);
     const stContracts = await stDeployHelper.deployStateV2();
     const contracts = await deployHelper.deployIdentity(
         stContracts.state,
@@ -37,7 +49,7 @@ describe("Next tests reproduce identity life cycle", function() {
       console.log(identity.address);
 
       expect(id).to.be.equal(
-        18148217572028590643859359173103611579212110941630801448409877263163593218n
+        16318200065989903207865860093614592605747279308745685922538039864771744258n
       );
 
       console.log(BigInt(id).toString(16));


### PR DESCRIPTION
Fix ID calculation.

Todo:
- [x] Fix test vectors for GenesisUtils.sol - they are in wrong byte order (reversed compared to IDs in state contract) @volodymyr-basiuk 
- [x] Fix unit test of ID generation for onchain identity. Fails because contract address differs depending on whether it was called separately or all tests together. To fix this we need to switch from default signer to fresh ethereum account to deploy Onchain Identity contract to get always the same contract address.