### PR TITLE
IOnchainCredentialStatusResolver Interface and fixed method signature

### DIFF
--- a/contracts/interfaces/IOnchainCredentialStatusResolver.sol
+++ b/contracts/interfaces/IOnchainCredentialStatusResolver.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.16;
+
+interface IOnchainCredentialStatusResolver {
+    /**
+     * @dev Struct of the node proof in the SMT.
+     * @param root SMT root.
+     * @param existence A flag, which shows if the leaf index exists in the SMT.
+     * @param siblings An array of SMT sibling node hashes.
+     * @param index An index of the leaf in the SMT.
+     * @param value A value of the leaf in the SMT.
+     * @param auxExistence A flag, which shows if the auxiliary leaf exists in the SMT.
+     * @param auxIndex An index of the auxiliary leaf in the SMT.
+     * @param auxValue A value of the auxiliary leaf in the SMT.
+     */
+    struct Proof {
+        uint256 root;
+        bool existence;
+        uint256[] siblings;
+        uint256 index;
+        uint256 value;
+        bool auxExistence;
+        uint256 auxIndex;
+        uint256 auxValue;
+    }
+
+    /**
+     * @dev Struct to represent Identity State and it's Roots
+     * @param state An identity state
+     * @param claimsTreeRoot A root of the claims tree
+     * @param revocationTreeRoot A root of the revocation tree
+     * @param rootOfRoots A root of the roots tree
+     */
+    struct IdentityStateRoots {
+        uint256 state;
+        uint256 claimsTreeRoot;
+        uint256 revocationTreeRoot;
+        uint256 rootOfRoots;
+    }
+
+    /**
+     * @dev Credential Status Struct
+     * @param issuer Issuer's identity state and roots
+     * @param mtp A Merkle Tree Proof of credential revocation or non-revocation
+     */
+    struct CredentialStatus {
+        IdentityStateRoots issuer;
+        Proof mtp;
+    }
+
+    /**
+     * @dev returns revocation status of a claim using given revocation nonce
+     * @param id Issuer's identifier
+     * @param nonce Revocation nonce
+     * @return CredentialStatus
+     */
+    function getRevocationStatus(uint256 id, uint64 nonce) external view returns (CredentialStatus memory);
+
+}

--- a/contracts/interfaces/IOnchainCredentialStatusResolver.sol
+++ b/contracts/interfaces/IOnchainCredentialStatusResolver.sol
@@ -54,6 +54,9 @@ interface IOnchainCredentialStatusResolver {
      * @param nonce Revocation nonce
      * @return CredentialStatus
      */
-    function getRevocationStatus(uint256 id, uint64 nonce) external view returns (CredentialStatus memory);
+    function getRevocationStatus(
+        uint256 id,
+        uint64 nonce
+    ) external view returns (CredentialStatus memory);
 
 }

--- a/contracts/interfaces/IOnchainCredentialStatusResolver.sol
+++ b/contracts/interfaces/IOnchainCredentialStatusResolver.sol
@@ -58,5 +58,4 @@ interface IOnchainCredentialStatusResolver {
         uint256 id,
         uint64 nonce
     ) external view returns (CredentialStatus memory);
-
 }

--- a/contracts/lib/IdentityBase.sol
+++ b/contracts/lib/IdentityBase.sol
@@ -11,15 +11,21 @@ import "../lib/OnChainIdentity.sol";
 //  */
 contract IdentityBase is IOnchainCredentialStatusResolver {
 
+    // This empty reserved space is put in place to allow future versions
+    // of this contract to add new parent contracts without shifting down
+    // storage of child contracts that use this contract as a base
+    // (see https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#storage-gaps)
+    uint256[500] private __gapBefore;
+
     using OnChainIdentity for OnChainIdentity.Identity;
 
     OnChainIdentity.Identity internal identity;
 
     // This empty reserved space is put in place to allow future versions
-    // of the SMT library to add new Data struct fields without shifting down
-    // storage of upgradable contracts that use this struct as a state variable
+    // of this contract to add new variables without shifting down
+    // storage of child contracts that use this contract as a base
     // (see https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#storage-gaps)
-    uint256[49] private __gap;
+    uint256[49] private __gapAfter;
 
     function getSmtDepth() public pure virtual returns (uint256) {
         return 40;

--- a/contracts/state/StateV2.sol
+++ b/contracts/state/StateV2.sol
@@ -103,7 +103,7 @@ contract StateV2 is Ownable2StepUpgradeable, IState {
         uint256 oldState,
         uint256 newState,
         bool isOldStateGenesis
-    ) private {
+    ) internal {
         require(id != 0, "ID should not be zero");
         require(newState != 0, "New state should not be zero");
         require(!stateExists(id, newState), "New state already exists");


### PR DESCRIPTION
* Added IOnchainCredentialStatusResolver Interface.
* Fixed signature of the getRevocationStatus method (it was missing id of issuer for the generic OnchainCredentialStatus contract).
* Changed visibility of _transitState function from private to internal.