### PR TITLE
Script to deploy poseidon contracts

### DIFF
--- a/helpers/PoseidonDeployHelper.ts
+++ b/helpers/PoseidonDeployHelper.ts
@@ -46,7 +46,7 @@ export async function deployPoseidons(
   return result;
 }
 
-export async function deployPoseidonFacade(): Promise<Contract> {
+export async function deployPoseidonFacade(): Promise<any> {
   const poseidonContracts = await deployPoseidons(
     (
       await ethers.getSigners()
@@ -71,5 +71,14 @@ export async function deployPoseidonFacade(): Promise<Contract> {
   const poseidonFacade = await PoseidonFacade.deploy();
   await poseidonFacade.deployed();
   console.log("PoseidonFacade deployed to:", poseidonFacade.address);
-  return poseidonFacade;
+  return {
+    PoseidonFacade: poseidonFacade,
+    PoseidonUnit1L: poseidonContracts[0],
+    PoseidonUnit2L: poseidonContracts[1],
+    PoseidonUnit3L: poseidonContracts[2],
+    PoseidonUnit4L: poseidonContracts[3],
+    PoseidonUnit5L: poseidonContracts[4],
+    PoseidonUnit6L: poseidonContracts[5],
+    SpongePoseidon: spongePoseidon,
+  };
 }

--- a/scripts/deployPoseidon.ts
+++ b/scripts/deployPoseidon.ts
@@ -1,0 +1,34 @@
+import fs from "fs";
+import path from "path";
+import {DeployHelper} from "../helpers/DeployHelper";
+import {deployPoseidonFacade} from "../helpers/PoseidonDeployHelper";
+
+async function main() {
+  const deployHelper = await DeployHelper.initialize(null, true);
+
+  const deployInfo: any = [];
+  const contracts = await deployPoseidonFacade();
+  deployInfo.push({
+    PoseidonFacade: contracts.PoseidonFacade.address,
+    PoseidonUnit1L: contracts.PoseidonUnit1L.address,
+    PoseidonUnit2L: contracts.PoseidonUnit2L.address,
+    PoseidonUnit3L: contracts.PoseidonUnit3L.address,
+    PoseidonUnit4L: contracts.PoseidonUnit4L.address,
+    PoseidonUnit5L: contracts.PoseidonUnit5L.address,
+    PoseidonUnit6L: contracts.PoseidonUnit6L.address,
+    SpongePoseidon: contracts.SpongePoseidon.address,
+  });
+  const outputJson = {
+    info: deployInfo,
+    network: process.env.HARDHAT_NETWORK,
+  };
+  const pathOutputJson = path.join(__dirname, "./deploy_poseidon_" + process.env.HARDHAT_NETWORK + ".json");
+  fs.writeFileSync(pathOutputJson, JSON.stringify(outputJson, null, 1));
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/test/poseidon/poseidon.test.ts
+++ b/test/poseidon/poseidon.test.ts
@@ -6,7 +6,8 @@ describe("poseidon", () => {
   let poseidonFacade: Contract;
 
   before(async () => {
-    poseidonFacade = await deployPoseidonFacade();
+    let poseidonContracts = await deployPoseidonFacade();
+    poseidonFacade = poseidonContracts.PoseidonFacade;
   });
 
   it("check poseidon hash function with inputs [1, 2]", async () => {


### PR DESCRIPTION
Script to deploy only poseidon contracts (hash 1-6 inputs, sponge and facade).
E.g. facade is needed for verifier contracts and it's not deployed with State.