### PR TITLE
Update Deployment Script Extension in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Uncomment networks object and updated blockchain provider **url** and **private 
 Then run the deployment script:
 
 ```shell
-npx hardhat run --network <your-network> scripts/deploy.js
+npx hardhat run --network <your-network> scripts/deploy.ts
 ```
 
 ## Run tests


### PR DESCRIPTION
This PR addresses a minor typo in the README file. The deployment command provided in the README uses the `.js` extension for the deployment script, but the actual file in the repository has a `.ts` extension.

**Changes:**
- Updated the deployment command in the README from `npx hardhat run --network <your-network> scripts/deploy.js` to `npx hardhat run --network <your-network> scripts/deploy.ts`

This change will help avoid any confusion for users trying to deploy using the instructions in the README.