### PR TITLE
Deploy poseidon4 with libraries

### DIFF
--- a/helpers/constants.ts
+++ b/helpers/constants.ts
@@ -164,6 +164,11 @@ export const contractsInfo = Object.freeze({
     unifiedAddress: "0x5Bc89782d5eBF62663Df7Ce5fb4bc7408926A240",
     create2Calldata: "",
   },
+  POSEIDON_4: {
+    name: "PoseidonUnit4L",
+    unifiedAddress: "0x0695cF2c6dfc438a4E40508741888198A6ccacC2",
+    create2Calldata: "",
+  },
   GROTH16_VERIFIER_STATE_TRANSITION: {
     name: "Groth16VerifierStateTransition",
     unifiedAddress: "0xAE950A9B8F48bC4519820728E210515a07F7cB71",

--- a/helpers/helperUtils.ts
+++ b/helpers/helperUtils.ts
@@ -1,7 +1,12 @@
 import { Contract, ContractTransactionResponse, JsonRpcProvider } from "ethers";
 import hre, { ethers, network } from "hardhat";
 import fs from "fs";
-import { contractsInfo, networks } from "./constants";
+import {
+  contractsInfo,
+  networks,
+  STATE_ADDRESS_POLYGON_AMOY,
+  STATE_ADDRESS_POLYGON_MAINNET,
+} from "./constants";
 import { poseidonContract } from "circomlibjs";
 
 export function getConfig() {
@@ -124,6 +129,20 @@ export async function getUnifiedContract(contractName: string): Promise<Contract
     }
     return ethers.getContractAt(contractName, contractAddress);
   }
+}
+
+export async function getStateContractAddress(): Promise<string> {
+  const chainId = hre.network.config.chainId;
+
+  let stateContractAddress = contractsInfo.STATE.unifiedAddress;
+  if (chainId === networks.POLYGON_AMOY.chainId) {
+    stateContractAddress = STATE_ADDRESS_POLYGON_AMOY;
+  }
+  if (chainId === networks.POLYGON_MAINNET.chainId) {
+    stateContractAddress = STATE_ADDRESS_POLYGON_MAINNET;
+  }
+
+  return stateContractAddress;
 }
 
 export class Logger {

--- a/scripts/deploy/deployIdentityExample.ts
+++ b/scripts/deploy/deployIdentityExample.ts
@@ -1,30 +1,16 @@
 import fs from "fs";
 import path from "path";
 import { OnchainIdentityDeployHelper } from "../../helpers/OnchainIdentityDeployHelper";
-import { deployPoseidons } from "../../helpers/PoseidonDeployHelper";
 import { DeployHelper } from "../../helpers/DeployHelper";
-import {
-  networks,
-  STATE_ADDRESS_POLYGON_AMOY,
-  STATE_ADDRESS_POLYGON_MAINNET,
-  contractsInfo,
-} from "../../helpers/constants";
+import { contractsInfo } from "../../helpers/constants";
 const pathOutputJson = path.join(__dirname, "./deploy_identity_example_output.json");
-import hre from "hardhat";
+import { getStateContractAddress } from "../../helpers/helperUtils";
 
 async function main() {
   const stDeployHelper = await DeployHelper.initialize();
   const { defaultIdType } = await stDeployHelper.getDefaultIdType();
 
-  const chainId = hre.network.config.chainId;
-
-  let stateContractAddress = contractsInfo.STATE.unifiedAddress;
-  if (chainId === networks.POLYGON_AMOY.chainId) {
-    stateContractAddress = STATE_ADDRESS_POLYGON_AMOY;
-  }
-  if (chainId === networks.POLYGON_MAINNET.chainId) {
-    stateContractAddress = STATE_ADDRESS_POLYGON_MAINNET;
-  }
+  const stateContractAddress = await getStateContractAddress();
 
   const identityDeployHelper = await OnchainIdentityDeployHelper.initialize();
 

--- a/scripts/deploy/deployIdentityExample.ts
+++ b/scripts/deploy/deployIdentityExample.ts
@@ -27,13 +27,12 @@ async function main() {
   }
 
   const identityDeployHelper = await OnchainIdentityDeployHelper.initialize();
-  const [poseidon4Elements] = await deployPoseidons([4]);
 
   const contracts = await identityDeployHelper.deployIdentity(
     stateContractAddress,
     contractsInfo.SMT_LIB.unifiedAddress,
     contractsInfo.POSEIDON_3.unifiedAddress,
-    await poseidon4Elements.getAddress(),
+    contractsInfo.POSEIDON_4.unifiedAddress,
     defaultIdType,
   );
 
@@ -46,7 +45,7 @@ async function main() {
     poseidon1: contractsInfo.POSEIDON_1.unifiedAddress,
     poseidon2: contractsInfo.POSEIDON_2.unifiedAddress,
     poseidon3: contractsInfo.POSEIDON_3.unifiedAddress,
-    poseidon4: poseidon4Elements.getAddress(),
+    poseidon4: contractsInfo.POSEIDON_4.unifiedAddress,
     network: process.env.HARDHAT_NETWORK,
   };
   fs.writeFileSync(pathOutputJson, JSON.stringify(outputJson, null, 1));

--- a/scripts/deploy/deployIdentityTreeStore.ts
+++ b/scripts/deploy/deployIdentityTreeStore.ts
@@ -1,27 +1,16 @@
 import { DeployHelper } from "../../helpers/DeployHelper";
-import hre, { ethers, network } from "hardhat";
+import hre, { ethers } from "hardhat";
 import path from "path";
 import fs from "fs";
-import { getConfig, isContract } from "../../helpers/helperUtils";
-import {
-  networks,
-  STATE_ADDRESS_POLYGON_AMOY,
-  STATE_ADDRESS_POLYGON_MAINNET,
-  contractsInfo,
-} from "../../helpers/constants";
+import { getConfig, getStateContractAddress } from "../../helpers/helperUtils";
+import { contractsInfo } from "../../helpers/constants";
 
 (async () => {
   const config = getConfig();
 
   const chainId = hre.network.config.chainId;
 
-  let stateContractAddress = contractsInfo.STATE.unifiedAddress;
-  if (chainId === networks.POLYGON_AMOY.chainId) {
-    stateContractAddress = STATE_ADDRESS_POLYGON_AMOY;
-  }
-  if (chainId === networks.POLYGON_MAINNET.chainId) {
-    stateContractAddress = STATE_ADDRESS_POLYGON_MAINNET;
-  }
+  const stateContractAddress = await getStateContractAddress();
 
   const deployStrategy: "basic" | "create2" =
     config.deployStrategy == "create2" ? "create2" : "basic";

--- a/scripts/deploy/deployLibraries.ts
+++ b/scripts/deploy/deployLibraries.ts
@@ -12,10 +12,8 @@ async function main() {
 
   const deployHelper = await DeployHelper.initialize(null, true);
 
-  const [poseidon1Elements, poseidon2Elements, poseidon3Elements] = await deployPoseidons(
-    [1, 2, 3],
-    deployStrategy,
-  );
+  const [poseidon1Elements, poseidon2Elements, poseidon3Elements, poseidon4Elements] =
+    await deployPoseidons([1, 2, 3, 4], deployStrategy);
 
   const smtLib = await deployHelper.deploySmtLib(
     await poseidon2Elements.getAddress(),
@@ -53,6 +51,7 @@ async function main() {
     poseidon1: await poseidon1Elements.getAddress(),
     poseidon2: await poseidon2Elements.getAddress(),
     poseidon3: await poseidon3Elements.getAddress(),
+    poseidon4: await poseidon4Elements.getAddress(),
     smtLib: await smtLib.getAddress(),
     groth16verifiersInfo,
     network: networkName,

--- a/scripts/deploy/deployUniversalVerifier.ts
+++ b/scripts/deploy/deployUniversalVerifier.ts
@@ -4,28 +4,18 @@ import { DeployHelper } from "../../helpers/DeployHelper";
 import hre, { ethers } from "hardhat";
 import {
   getConfig,
+  getStateContractAddress,
   Logger,
   TempContractDeployments,
   waitNotToInterfereWithHardhatIgnition,
 } from "../../helpers/helperUtils";
-import {
-  networks,
-  contractsInfo,
-  STATE_ADDRESS_POLYGON_AMOY,
-  STATE_ADDRESS_POLYGON_MAINNET,
-} from "../../helpers/constants";
+import { contractsInfo } from "../../helpers/constants";
 
 async function main() {
   const config = getConfig();
   const chainId = hre.network.config.chainId;
 
-  let stateContractAddress = contractsInfo.STATE.unifiedAddress;
-  if (chainId === networks.POLYGON_AMOY.chainId) {
-    stateContractAddress = STATE_ADDRESS_POLYGON_AMOY;
-  }
-  if (chainId === networks.POLYGON_MAINNET.chainId) {
-    stateContractAddress = STATE_ADDRESS_POLYGON_MAINNET;
-  }
+  const stateContractAddress = await getStateContractAddress();
   const deployStrategy: "basic" | "create2" =
     config.deployStrategy == "create2" ? "create2" : "basic";
   const [signer] = await ethers.getSigners();

--- a/scripts/deploy/deployValidators.ts
+++ b/scripts/deploy/deployValidators.ts
@@ -2,25 +2,14 @@ import fs from "fs";
 import path from "path";
 import { DeployHelper } from "../../helpers/DeployHelper";
 import hre from "hardhat";
-import { getConfig } from "../../helpers/helperUtils";
-import {
-  networks,
-  STATE_ADDRESS_POLYGON_AMOY,
-  STATE_ADDRESS_POLYGON_MAINNET,
-  contractsInfo,
-} from "../../helpers/constants";
+import { getConfig, getStateContractAddress } from "../../helpers/helperUtils";
+import { contractsInfo } from "../../helpers/constants";
 
 async function main() {
   const config = getConfig();
   const chainId = hre.network.config.chainId;
 
-  let stateContractAddress = contractsInfo.STATE.unifiedAddress;
-  if (chainId === networks.POLYGON_AMOY.chainId) {
-    stateContractAddress = STATE_ADDRESS_POLYGON_AMOY;
-  }
-  if (chainId === networks.POLYGON_MAINNET.chainId) {
-    stateContractAddress = STATE_ADDRESS_POLYGON_MAINNET;
-  }
+  const stateContractAddress = await getStateContractAddress();
   const validators: ("mtpV2" | "sigV2" | "v3")[] = ["mtpV2", "sigV2", "v3"];
   const groth16VerifierWrappers = [
     {

--- a/scripts/maintenance/multi-chain/checkOracleSigningAddress.ts
+++ b/scripts/maintenance/multi-chain/checkOracleSigningAddress.ts
@@ -1,12 +1,11 @@
-import { getProviders, isContract, Logger } from "../../../helpers/helperUtils";
 import {
-  contractsInfo,
-  networks,
-  ORACLE_SIGNING_ADDRESS_PRODUCTION,
-  STATE_ADDRESS_POLYGON_AMOY,
-  STATE_ADDRESS_POLYGON_MAINNET,
-} from "../../../helpers/constants";
-import hre, { ethers } from "hardhat";
+  getProviders,
+  getStateContractAddress,
+  isContract,
+  Logger,
+} from "../../../helpers/helperUtils";
+import { contractsInfo, ORACLE_SIGNING_ADDRESS_PRODUCTION } from "../../../helpers/constants";
+import { ethers } from "hardhat";
 
 async function main() {
   const providers = getProviders();
@@ -14,15 +13,7 @@ async function main() {
   for (const provider of providers) {
     const jsonRpcProvider = new ethers.JsonRpcProvider(provider.rpcUrl);
 
-    const chainId = hre.network.config.chainId;
-
-    let stateContractAddress = contractsInfo.STATE.unifiedAddress;
-    if (chainId === networks.POLYGON_AMOY.chainId) {
-      stateContractAddress = STATE_ADDRESS_POLYGON_AMOY;
-    }
-    if (chainId === networks.POLYGON_MAINNET.chainId) {
-      stateContractAddress = STATE_ADDRESS_POLYGON_MAINNET;
-    }
+    const stateContractAddress = await getStateContractAddress();
 
     let oracleSigningAddressIsValid = true;
     const defaultOracleSigningAddress = ORACLE_SIGNING_ADDRESS_PRODUCTION; // production signing address

--- a/scripts/maintenance/setOracleSigningAddress.ts
+++ b/scripts/maintenance/setOracleSigningAddress.ts
@@ -1,25 +1,11 @@
 import { ethers } from "hardhat";
-import {
-  networks,
-  contractsInfo,
-  ORACLE_SIGNING_ADDRESS_PRODUCTION,
-  STATE_ADDRESS_POLYGON_AMOY,
-  STATE_ADDRESS_POLYGON_MAINNET,
-} from "../../helpers/constants";
-import hre from "hardhat";
+import { contractsInfo, ORACLE_SIGNING_ADDRESS_PRODUCTION } from "../../helpers/constants";
+import { getStateContractAddress } from "../../helpers/helperUtils";
 
 async function main() {
   const oracleSigningAddress = ORACLE_SIGNING_ADDRESS_PRODUCTION; // production signing address
 
-  const chainId = hre.network.config.chainId;
-
-  let stateContractAddress = contractsInfo.STATE.unifiedAddress as string;
-  if (chainId === networks.POLYGON_AMOY.chainId) {
-    stateContractAddress = STATE_ADDRESS_POLYGON_AMOY;
-  }
-  if (chainId === networks.POLYGON_MAINNET.chainId) {
-    stateContractAddress = STATE_ADDRESS_POLYGON_MAINNET;
-  }
+  const stateContractAddress = await getStateContractAddress();
   const state = await ethers.getContractAt(contractsInfo.STATE.name, stateContractAddress);
   const crossChainProofValidatorAddress = await state.getCrossChainProofValidator();
   console.log(`CrossChainProofValidator address: ${crossChainProofValidatorAddress}`);

--- a/scripts/upgrade/identitytreestore/identitytreestore-upgrade.ts
+++ b/scripts/upgrade/identitytreestore/identitytreestore-upgrade.ts
@@ -1,14 +1,13 @@
 import hre, { ethers } from "hardhat";
 import { DeployHelper } from "../../../helpers/DeployHelper";
-import { getConfig, removeLocalhostNetworkIgnitionFiles } from "../../../helpers/helperUtils";
+import {
+  getConfig,
+  getStateContractAddress,
+  removeLocalhostNetworkIgnitionFiles,
+} from "../../../helpers/helperUtils";
 import path from "path";
 import fs from "fs";
-import {
-  networks,
-  contractsInfo,
-  STATE_ADDRESS_POLYGON_AMOY,
-  STATE_ADDRESS_POLYGON_MAINNET,
-} from "../../../helpers/constants";
+import { contractsInfo } from "../../../helpers/constants";
 
 const removePreviousIgnitionFiles = true;
 const impersonate = false;
@@ -36,13 +35,7 @@ async function main() {
     throw new Error("LEDGER_ACCOUNT is not set");
   }
 
-  let stateContractAddress = contractsInfo.STATE.unifiedAddress;
-  if (chainId === networks.POLYGON_AMOY.chainId) {
-    stateContractAddress = STATE_ADDRESS_POLYGON_AMOY;
-  }
-  if (chainId === networks.POLYGON_MAINNET.chainId) {
-    stateContractAddress = STATE_ADDRESS_POLYGON_MAINNET;
-  }
+  const stateContractAddress = await getStateContractAddress();
 
   const { proxyAdminOwnerSigner } = await getSigners(impersonate);
 

--- a/scripts/upgrade/state/state-upgrade.ts
+++ b/scripts/upgrade/state/state-upgrade.ts
@@ -2,15 +2,14 @@ import { DeployHelper } from "../../../helpers/DeployHelper";
 import hre, { ethers } from "hardhat";
 import { expect } from "chai"; // abi of contract that will be upgraded
 import * as stateArtifact from "../../../artifacts/contracts/state/State.sol/State.json";
-import { getConfig, removeLocalhostNetworkIgnitionFiles } from "../../../helpers/helperUtils";
+import {
+  getConfig,
+  getStateContractAddress,
+  removeLocalhostNetworkIgnitionFiles,
+} from "../../../helpers/helperUtils";
 import fs from "fs";
 import path from "path";
-import {
-  networks,
-  STATE_ADDRESS_POLYGON_AMOY,
-  STATE_ADDRESS_POLYGON_MAINNET,
-  contractsInfo,
-} from "../../../helpers/constants";
+import { contractsInfo } from "../../../helpers/constants";
 
 const config = getConfig();
 
@@ -42,13 +41,7 @@ async function main() {
     throw new Error("LEDGER_ACCOUNT is not set");
   }
 
-  let stateContractAddress = contractsInfo.STATE.unifiedAddress;
-  if (chainId === networks.POLYGON_AMOY.chainId) {
-    stateContractAddress = STATE_ADDRESS_POLYGON_AMOY;
-  }
-  if (chainId === networks.POLYGON_MAINNET.chainId) {
-    stateContractAddress = STATE_ADDRESS_POLYGON_MAINNET;
-  }
+  const stateContractAddress = await getStateContractAddress();
   const { proxyAdminOwnerSigner, stateOwnerSigner } = await getSigners(impersonate);
 
   const stateDeployHelper = await DeployHelper.initialize(

--- a/scripts/upgrade/verifiers/verifier-upgrade.ts
+++ b/scripts/upgrade/verifiers/verifier-upgrade.ts
@@ -12,15 +12,11 @@ import {
 } from "./helpers/testVerifier";
 import {
   getConfig,
+  getStateContractAddress,
   removeLocalhostNetworkIgnitionFiles,
   waitNotToInterfereWithHardhatIgnition,
 } from "../../../helpers/helperUtils";
-import {
-  networks,
-  contractsInfo,
-  STATE_ADDRESS_POLYGON_AMOY,
-  STATE_ADDRESS_POLYGON_MAINNET,
-} from "../../../helpers/constants";
+import { contractsInfo } from "../../../helpers/constants";
 import fs from "fs";
 import path from "path";
 
@@ -57,12 +53,7 @@ async function main() {
   if (!ethers.isAddress(config.ledgerAccount)) {
     throw new Error("LEDGER_ACCOUNT is not set");
   }
-  if (chainId === networks.POLYGON_AMOY.chainId) {
-    stateContractAddress = STATE_ADDRESS_POLYGON_AMOY;
-  }
-  if (chainId === networks.POLYGON_MAINNET.chainId) {
-    stateContractAddress = STATE_ADDRESS_POLYGON_MAINNET;
-  }
+  stateContractAddress = await getStateContractAddress();
 
   const { proxyAdminOwnerSigner, universalVerifierOwnerSigner } = await getSigners(impersonate);
 


### PR DESCRIPTION
We have decided to include Poseidon4 in deployments with the libraries and unified addresses because it's needed if someone wants to deploy Identity Example for onchain Issuer identity.

Also added some refactor for getting state contract address from chainId. 