### PR TITLE
Add check for correct Id Types in state contract in all networks

### DIFF
--- a/helpers/helperUtils.ts
+++ b/helpers/helperUtils.ts
@@ -181,8 +181,10 @@ export async function getUnifiedContract(contractName: string): Promise<Contract
   }
 }
 
-export function getStateContractAddress(): string {
-  const chainId = hre.network.config.chainId;
+export function getStateContractAddress(chainId?: number): string {
+  if (!chainId) {
+    chainId = hre.network.config.chainId;
+  }
 
   let stateContractAddress = contractsInfo.STATE.unifiedAddress;
   if (chainId === networks.POLYGON_AMOY.chainId) {

--- a/scripts/maintenance/multi-chain/checkIdTypes.ts
+++ b/scripts/maintenance/multi-chain/checkIdTypes.ts
@@ -1,0 +1,92 @@
+import {
+  getProviders,
+  getStateContractAddress,
+  isContract,
+  Logger,
+} from "../../../helpers/helperUtils";
+import { contractsInfo, networks } from "../../../helpers/constants";
+import { ethers } from "hardhat";
+
+async function main() {
+  const providers = getProviders();
+
+  for (const provider of providers) {
+    const jsonRpcProvider = new ethers.JsonRpcProvider(provider.rpcUrl);
+    const chainId = Number((await jsonRpcProvider.getNetwork()).chainId);
+
+    const stateContractAddress = getStateContractAddress(chainId);
+
+    let defaultIdTypeIsValid = false;
+    let supportedIdTypesAreValid = false;
+    let defaultIdType;
+    let supportedIdTypeToCheck;
+    let isIdTypeToCheckSupported = false;
+    let isDefaultIdTypeSupported = false;
+    if (!(await isContract(stateContractAddress, jsonRpcProvider))) {
+      defaultIdTypeIsValid = false;
+    } else {
+      const wallet = new ethers.Wallet(process.env.PRIVATE_KEY as string, jsonRpcProvider);
+      const state = await ethers.getContractAt(
+        contractsInfo.STATE.name,
+        stateContractAddress,
+        wallet,
+      );
+      defaultIdType = await state.getDefaultIdType();
+
+      if (defaultIdType.startsWith("0x01")) {
+        // 0x01 is the prefix for the default id type iden3
+        defaultIdTypeIsValid = true;
+      }
+
+      supportedIdTypeToCheck = defaultIdType.replace("0x01", "0x02");
+      isDefaultIdTypeSupported = await state.isIdTypeSupported(defaultIdType);
+
+      isIdTypeToCheckSupported = await state.isIdTypeSupported(supportedIdTypeToCheck);
+      if (
+        !isIdTypeToCheckSupported ||
+        [networks.POLYGON_AMOY.chainId, networks.POLYGON_MAINNET.chainId].includes(chainId)
+      ) {
+        supportedIdTypesAreValid = true;
+      }
+    }
+
+    if (!defaultIdTypeIsValid) {
+      Logger.error(`${provider.network}: Default Id Type ${defaultIdType} is not valid`);
+    } else {
+      Logger.success(`${provider.network}: Default Id Type ${defaultIdType} is valid`);
+    }
+
+    if (!supportedIdTypesAreValid) {
+      Logger.error(
+        `${provider.network}: Invalid supported Id Types: ${
+          isDefaultIdTypeSupported
+            ? `${defaultIdType} is supported`
+            : `${defaultIdType} is not supported`
+        }, ${
+          isIdTypeToCheckSupported
+            ? `${supportedIdTypeToCheck} is supported`
+            : `${supportedIdTypeToCheck} is not supported`
+        }\n`,
+      );
+    } else {
+      Logger.success(
+        `${provider.network}: Supported Id Types are valid: ${
+          isDefaultIdTypeSupported
+            ? `${defaultIdType} is supported`
+            : `${defaultIdType} is not supported`
+        }, ${
+          isIdTypeToCheckSupported
+            ? `${supportedIdTypeToCheck} is supported`
+            : `${supportedIdTypeToCheck} is not supported`
+        }\n`,
+      );
+    }
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/maintenance/multi-chain/checkIdTypes.ts
+++ b/scripts/maintenance/multi-chain/checkIdTypes.ts
@@ -62,10 +62,12 @@ async function main() {
           isDefaultIdTypeSupported
             ? `${defaultIdType} is supported`
             : `${defaultIdType} is not supported`
-        }, ${
-          isIdTypeToCheckSupported
-            ? `${supportedIdTypeToCheck} is supported`
-            : `${supportedIdTypeToCheck} is not supported`
+        }${
+          defaultIdType !== supportedIdTypeToCheck
+            ? isIdTypeToCheckSupported
+              ? `, ${supportedIdTypeToCheck} is supported`
+              : `, ${supportedIdTypeToCheck} is not supported`
+            : ""
         }\n`,
       );
     } else {

--- a/scripts/maintenance/setSupportedIdTypes.ts
+++ b/scripts/maintenance/setSupportedIdTypes.ts
@@ -1,0 +1,71 @@
+import { getStateContractAddress } from "../../helpers/helperUtils";
+import { contractsInfo, networks } from "../../helpers/constants";
+import hre, { ethers } from "hardhat";
+import { expect } from "chai";
+
+async function main() {
+  const stateContractAddress = getStateContractAddress();
+  const chainId = Number(hre.network.config.chainId);
+
+  const state = await ethers.getContractAt(contractsInfo.STATE.name, stateContractAddress);
+  const defaultIdType = await state.getDefaultIdType();
+
+  let iden3DefaultIdType;
+  let defaultIdTypeIsValid = false;
+
+  if (defaultIdType.startsWith("0x01")) {
+    // 0x01 is the prefix for the iden3 id type
+    // 0x02 is the prefix for the polygon id type
+    defaultIdTypeIsValid = true;
+    iden3DefaultIdType = defaultIdType;
+  } else {
+    iden3DefaultIdType = defaultIdType.replace("0x02", "0x01");
+    const tx = await state.setDefaultIdType(defaultIdType);
+    await tx.wait();
+  }
+
+  const polygonIdType = defaultIdType.replace("0x01", "0x02");
+
+  if (!defaultIdTypeIsValid) {
+    let tx = await state.setSupportedIdType(defaultIdType, false);
+    await tx.wait();
+    tx = await state.setSupportedIdType(iden3DefaultIdType, true);
+    await tx.wait();
+  } else {
+    const isDefaultIdTypeSupported = await state.isIdTypeSupported(defaultIdType);
+    if (!isDefaultIdTypeSupported) {
+      const tx = await state.setSupportedIdType(defaultIdType, true);
+      await tx.wait();
+    }
+    const isPolygonIdTypeSupported = await state.isIdTypeSupported(polygonIdType);
+
+    if (
+      isPolygonIdTypeSupported &&
+      ![networks.POLYGON_AMOY.chainId, networks.POLYGON_MAINNET.chainId].includes(chainId)
+    ) {
+      const tx = await state.setSupportedIdType(polygonIdType, false);
+      await tx.wait();
+    }
+    if (
+      !isPolygonIdTypeSupported &&
+      [networks.POLYGON_AMOY.chainId, networks.POLYGON_MAINNET.chainId].includes(chainId)
+    ) {
+      const tx = await state.setSupportedIdType(polygonIdType, true);
+      await tx.wait();
+    }
+  }
+
+  expect(await state.isIdTypeSupported(iden3DefaultIdType)).to.be.true;
+  if ([networks.POLYGON_AMOY.chainId, networks.POLYGON_MAINNET.chainId].includes(chainId)) {
+    expect(await state.isIdTypeSupported(polygonIdType)).to.be.true;
+  } else {
+    expect(await state.isIdTypeSupported(polygonIdType)).to.be.false;
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
To check for correct Id Types in State contract for all the networks:
```
npx hardhat run scripts/maintenance/multi-chain/checkIdTypes.ts
```

To fix Id Types in a specific network
```
npx hardhat run scripts/maintenance/setSupportedIdTypes.ts --network <network> 
```