### PR TITLE
Override submitZKPResponxeV2 for Embeddedzkpverifier

### DIFF
--- a/contracts/test-helpers/EmbeddedZKPVerifierWrapper.sol
+++ b/contracts/test-helpers/EmbeddedZKPVerifierWrapper.sol
@@ -3,9 +3,40 @@ pragma solidity 0.8.27;
 
 import {EmbeddedZKPVerifier} from "../verifiers/EmbeddedZKPVerifier.sol";
 import {IState} from "../interfaces/IState.sol";
+import {ICircuitValidator} from "../interfaces/ICircuitValidator.sol";
+import {IZKPVerifier} from "../interfaces/IZKPVerifier.sol";
 
 contract EmbeddedZKPVerifierWrapper is EmbeddedZKPVerifier {
+    event BeforeProofSubmit(uint64 requestId, uint256[] inputs, ICircuitValidator validator);
+    event AfterProofSubmit(uint64 requestId, uint256[] inputs, ICircuitValidator validator);
+    event BeforeProofSubmitV2(IZKPVerifier.ZKPResponse[] responses);
+    event AfterProofSubmitV2(IZKPVerifier.ZKPResponse[] responses);
+
     function initialize(address initialOwner, IState state) public initializer {
         super.__EmbeddedZKPVerifier_init(initialOwner, state);
+    }
+
+    function _beforeProofSubmit(
+        uint64 requestId,
+        uint256[] memory inputs,
+        ICircuitValidator validator
+    ) internal override {
+        emit BeforeProofSubmit(requestId, inputs, validator);
+    }
+
+    function _afterProofSubmit(
+        uint64 requestId,
+        uint256[] memory inputs,
+        ICircuitValidator validator
+    ) internal override {
+        emit AfterProofSubmit(requestId, inputs, validator);
+    }
+
+    function _beforeProofSubmitV2(IZKPVerifier.ZKPResponse[] memory responses) internal override {
+        emit BeforeProofSubmitV2(responses);
+    }
+
+    function _afterProofSubmitV2(IZKPVerifier.ZKPResponse[] memory responses) internal override {
+        emit AfterProofSubmitV2(responses);
     }
 }

--- a/contracts/test-helpers/Groth16VerifierValidatorStub.sol
+++ b/contracts/test-helpers/Groth16VerifierValidatorStub.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.27;
+
+import {IVerifier} from "../interfaces/IVerifier.sol";
+
+contract Groth16VerifierValidatorStub is IVerifier {
+    function verify(
+        uint256[2] calldata,
+        uint256[2][2] calldata,
+        uint256[2] calldata,
+        uint256[] calldata
+    ) external pure returns (bool r) {
+        return true;
+    }
+}

--- a/contracts/verifiers/EmbeddedZKPVerifier.sol
+++ b/contracts/verifiers/EmbeddedZKPVerifier.sol
@@ -9,18 +9,6 @@ import {IState} from "../interfaces/IState.sol";
 
 abstract contract EmbeddedZKPVerifier is Ownable2StepUpgradeable, ZKPVerifierBase {
     /**
-     * @dev RequestInfo. Structure with info about requests.
-     * @param requestId Identifier of the request.
-     * @param inputs Inputs of the circuit for this request.
-     * @param validator Validator circuit.
-     */
-    struct RequestInfo {
-        uint64 requestId;
-        uint256[] inputs;
-        ICircuitValidator validator;
-    }
-
-    /**
      * @dev Sets the value for Owner
      */
     function __EmbeddedZKPVerifier_init(
@@ -81,23 +69,9 @@ abstract contract EmbeddedZKPVerifier is Ownable2StepUpgradeable, ZKPVerifierBas
         IZKPVerifier.ZKPResponse[] memory responses,
         bytes memory crossChainProof
     ) public override {
-        RequestInfo[] memory requestInfo = new RequestInfo[](responses.length);
-        for (uint256 i = 0; i < responses.length; i++) {
-            IZKPVerifier.ZKPResponse memory response = responses[i];
-            IZKPVerifier.ZKPRequest memory request = getZKPRequest(response.requestId);
-            (
-                uint256[] memory inputs,
-                uint256[2] memory a,
-                uint256[2][2] memory b,
-                uint256[2] memory c
-            ) = abi.decode(response.zkProof, (uint256[], uint256[2], uint256[2][2], uint256[2]));
-
-            requestInfo[i] = RequestInfo(response.requestId, inputs, request.validator);
-        }
-
-        _beforeProofSubmitV2(requestInfo);
+        _beforeProofSubmitV2(responses);
         super.submitZKPResponseV2(responses, crossChainProof);
-        _afterProofSubmitV2(requestInfo);
+        _afterProofSubmitV2(responses);
     }
 
     /**
@@ -120,11 +94,13 @@ abstract contract EmbeddedZKPVerifier is Ownable2StepUpgradeable, ZKPVerifierBas
 
     /**
      * @dev Hook that is called before any proof response submit V2
+     * @param responses The list of responses including ZKP request ID, ZK proof and metadata
      */
-    function _beforeProofSubmitV2(RequestInfo[] memory requests) internal virtual {}
+    function _beforeProofSubmitV2(IZKPVerifier.ZKPResponse[] memory responses) internal virtual {}
 
     /**
      * @dev Hook that is called after any proof response submit V2
+     * @param responses The list of responses including ZKP request ID, ZK proof and metadata
      */
-    function _afterProofSubmitV2(RequestInfo[] memory requests) internal virtual {}
+    function _afterProofSubmitV2(IZKPVerifier.ZKPResponse[] memory responses) internal virtual {}
 }

--- a/helpers/DeployHelper.ts
+++ b/helpers/DeployHelper.ts
@@ -825,6 +825,16 @@ export class DeployHelper {
     return stubInstance;
   }
 
+  async deployGroth16VerifierValidatorStub(): Promise<Contract> {
+    const stub = await ethers.getContractFactory("Groth16VerifierValidatorStub");
+    const stubInstance = await stub.deploy();
+    await stubInstance.waitForDeployment();
+
+    console.log("Groth16 Verifier Validator stub deployed to:", await stubInstance.getAddress());
+
+    return stubInstance;
+  }
+
   async upgradeValidator(
     validatorAddress: string,
     validatorContractName: string,

--- a/test/utils/packData.ts
+++ b/test/utils/packData.ts
@@ -152,16 +152,15 @@ export async function buildCrossChainProofs(
 ): Promise<any[]> {
   const map = await Promise.all(
     crossChainProofsMessages.map(async (crossChainProofMessage) => {
-      if (crossChainProofMessage.idType) {
-        return {
-          proofType: "globalStateProof",
-          proof: await packGlobalStateUpdateWithSignature(crossChainProofMessage, signer),
-        };
-      }
-      return {
-        proofType: "stateProof",
-        proof: await packIdentityStateUpdateWithSignature(crossChainProofMessage, signer),
-      };
+      return crossChainProofMessage.idType
+        ? {
+            proofType: "globalStateProof",
+            proof: await packGlobalStateUpdateWithSignature(crossChainProofMessage, signer),
+          }
+        : {
+            proofType: "stateProof",
+            proof: await packIdentityStateUpdateWithSignature(crossChainProofMessage, signer),
+          };
     }),
   );
   return map;

--- a/test/utils/packData.ts
+++ b/test/utils/packData.ts
@@ -145,3 +145,24 @@ export function packZKProof(inputs: string[], a: string[], b: string[][], c: str
     [inputs, a, b, c],
   );
 }
+
+export async function buildCrossChainProofs(
+  crossChainProofsMessages: any[],
+  signer: any,
+): Promise<any[]> {
+  const map = await Promise.all(
+    crossChainProofsMessages.map(async (crossChainProofMessage) => {
+      if (crossChainProofMessage.idType) {
+        return {
+          proofType: "globalStateProof",
+          proof: await packGlobalStateUpdateWithSignature(crossChainProofMessage, signer),
+        };
+      }
+      return {
+        proofType: "stateProof",
+        proof: await packIdentityStateUpdateWithSignature(crossChainProofMessage, signer),
+      };
+    }),
+  );
+  return map;
+}

--- a/test/verifier/embedded-zkp-verifier.test.ts
+++ b/test/verifier/embedded-zkp-verifier.test.ts
@@ -4,12 +4,7 @@ import { ethers } from "hardhat";
 import { packValidatorParams } from "../utils/validator-pack-utils";
 import { prepareInputs } from "../utils/state-utils";
 import { Block, Signer } from "ethers";
-import {
-  packCrossChainProofs,
-  packGlobalStateUpdateWithSignature,
-  packIdentityStateUpdateWithSignature,
-  packZKProof,
-} from "../utils/packData";
+import { buildCrossChainProofs, packCrossChainProofs, packZKProof } from "../utils/packData";
 import proofJson from "../validators/sig/data/valid_sig_user_genesis.json";
 
 describe("Embedded ZKP Verifier", function () {
@@ -141,20 +136,13 @@ describe("Embedded ZKP Verifier", function () {
 
     const zkProof = packZKProof(inputs, pi_a, pi_b, pi_c);
     const [signer] = await ethers.getSigners();
-    const crossChainProofs = packCrossChainProofs([
-      {
-        proofType: "globalStateProof",
-        proof: await packGlobalStateUpdateWithSignature(globalStateMessage, signer),
-      },
-      {
-        proofType: "stateProof",
-        proof: await packIdentityStateUpdateWithSignature(identityStateMessage1, signer),
-      },
-      {
-        proofType: "stateProof",
-        proof: await packIdentityStateUpdateWithSignature(identityStateUpdate2, signer),
-      },
-    ]);
+
+    const crossChainProofs = packCrossChainProofs(
+      await buildCrossChainProofs(
+        [globalStateMessage, identityStateMessage1, identityStateUpdate2],
+        signer,
+      ),
+    );
 
     const metadatas = "0x";
 

--- a/test/verifier/embedded-zkp-verifier.test.ts
+++ b/test/verifier/embedded-zkp-verifier.test.ts
@@ -61,18 +61,13 @@ describe("Embedded ZKP Verifier", function () {
     // 2 events are emitted
     expect(receipt?.logs.length).to.equal(2);
 
-    const dataEvent1 = receipt?.logs[0].data;
-    const topicsEvent1 = receipt?.logs[0].topics;
-    const dataEvent2 = receipt?.logs[1].data;
-    const topicsEvent2 = receipt?.logs[1].topics;
-
     const interfaceEventBeforeProofSubmit = new ethers.Interface([
       "event BeforeProofSubmit(uint64 requestId, uint256[] inputs, address validator)",
     ]);
     const eventBeforeProofSubmit = interfaceEventBeforeProofSubmit.decodeEventLog(
       "BeforeProofSubmit",
-      dataEvent1!,
-      topicsEvent1,
+      receipt?.logs[0].data || "",
+      receipt?.logs[0].topics,
     );
     expect(eventBeforeProofSubmit[0]).to.equal(0);
     expect(eventBeforeProofSubmit[1]).to.deep.equal(inputs.map((x) => BigInt(x)));
@@ -83,8 +78,8 @@ describe("Embedded ZKP Verifier", function () {
     ]);
     const eventAfterProofSubmit = interfaceEventAfterProofSubmit.decodeEventLog(
       "AfterProofSubmit",
-      dataEvent2!,
-      topicsEvent2,
+      receipt?.logs[1].data || "",
+      receipt?.logs[1].topics,
     );
     expect(eventAfterProofSubmit[0]).to.equal(0);
     expect(eventAfterProofSubmit[1]).to.deep.equal(inputs.map((x) => BigInt(x)));
@@ -165,18 +160,13 @@ describe("Embedded ZKP Verifier", function () {
     // 2 events are emitted
     expect(receipt?.logs.length).to.equal(2);
 
-    const dataEvent1 = receipt?.logs[0].data;
-    const topicsEvent1 = receipt?.logs[0].topics;
-    const dataEvent2 = receipt?.logs[1].data;
-    const topicsEvent2 = receipt?.logs[1].topics;
-
     const interfaceEventBeforeProofSubmitV2 = new ethers.Interface([
       "event BeforeProofSubmitV2(tuple(uint64 requestId,bytes zkProof,bytes data)[])",
     ]);
     const eventBeforeProofSubmitV2 = interfaceEventBeforeProofSubmitV2.decodeEventLog(
       "BeforeProofSubmitV2",
-      dataEvent1!,
-      topicsEvent1,
+      receipt?.logs[0].data || "",
+      receipt?.logs[0].topics,
     );
     expect(eventBeforeProofSubmitV2[0][0][0]).to.equal(0);
     expect(eventBeforeProofSubmitV2[0][0][1]).to.deep.equal(zkProof);
@@ -187,8 +177,8 @@ describe("Embedded ZKP Verifier", function () {
     ]);
     const eventAfterProofSubmitV2 = interfaceEventAfterProofSubmitV2.decodeEventLog(
       "AfterProofSubmitV2",
-      dataEvent2!,
-      topicsEvent2,
+      receipt?.logs[1].data || "",
+      receipt?.logs[1].topics,
     );
     expect(eventAfterProofSubmitV2[0][0][0]).to.equal(0);
     expect(eventAfterProofSubmitV2[0][0][1]).to.deep.equal(zkProof);

--- a/test/verifier/universal-verifier-submit-V2.test.ts
+++ b/test/verifier/universal-verifier-submit-V2.test.ts
@@ -5,12 +5,7 @@ import { packValidatorParams } from "../utils/validator-pack-utils";
 import { prepareInputs } from "../utils/state-utils";
 import { Block, Contract } from "ethers";
 import proofJson from "../validators/sig/data/valid_sig_user_genesis.json";
-import {
-  packCrossChainProofs,
-  packGlobalStateUpdateWithSignature,
-  packIdentityStateUpdateWithSignature,
-  packZKProof,
-} from "../utils/packData";
+import { buildCrossChainProofs, packCrossChainProofs, packZKProof } from "../utils/packData";
 
 describe("Universal Verifier V2 MTP & SIG validators", function () {
   let verifier: any, sig: any;
@@ -96,20 +91,12 @@ describe("Universal Verifier V2 MTP & SIG validators", function () {
 
     const zkProof = packZKProof(inputs, pi_a, pi_b, pi_c);
 
-    const crossChainProofs = packCrossChainProofs([
-      {
-        proofType: "globalStateProof",
-        proof: await packGlobalStateUpdateWithSignature(globalStateMessage, signer),
-      },
-      {
-        proofType: "stateProof",
-        proof: await packIdentityStateUpdateWithSignature(identityStateMessage1, signer),
-      },
-      {
-        proofType: "stateProof",
-        proof: await packIdentityStateUpdateWithSignature(identityStateUpdate2, signer),
-      },
-    ]);
+    const crossChainProofs = packCrossChainProofs(
+      await buildCrossChainProofs(
+        [globalStateMessage, identityStateMessage1, identityStateUpdate2],
+        signer,
+      ),
+    );
 
     const metadatas = "0x";
 
@@ -164,20 +151,12 @@ describe("Universal Verifier V2 MTP & SIG validators", function () {
 
     const zkProof = packZKProof(inputs, pi_a, pi_b, pi_c);
 
-    const crossChainProofs = packCrossChainProofs([
-      {
-        proofType: "globalStateProof",
-        proof: await packGlobalStateUpdateWithSignature(globalStateMessage, signer),
-      },
-      {
-        proofType: "stateProof",
-        proof: await packIdentityStateUpdateWithSignature(identityStateMessage1, signer),
-      },
-      {
-        proofType: "stateProof",
-        proof: await packIdentityStateUpdateWithSignature(identityStateUpdate2, signer),
-      },
-    ]);
+    const crossChainProofs = packCrossChainProofs(
+      await buildCrossChainProofs(
+        [globalStateMessage, identityStateMessage1, identityStateUpdate2],
+        signer,
+      ),
+    );
 
     const metadatas = "0x";
 


### PR DESCRIPTION
Override the submitZKPResponseV2 for EmbeddedZKPVerifier

- Add the _beforeProofSubmitV2 and _afterProofSubmitV2 hooks.
- Need to figure out the interfaces for them. 
- Add the unit tests to `embedded-zkp-verifier.test.ts`. 
