### PR TITLE
Fix npm vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -906,27 +906,6 @@
         "ws": "7.4.6"
       }
     },
-    "node_modules/@ethersproject/providers/node_modules/ws": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@ethersproject/random": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
@@ -1431,37 +1410,25 @@
       }
     },
     "node_modules/@ledgerhq/domain-service": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/domain-service/-/domain-service-1.2.4.tgz",
-      "integrity": "sha512-Ycm4uTIHiZfkp3sWEBXbPjpQHTIQnlNpQHIJi70G3c8eY4CwlLxqBrBnY9ac9vmu16CuXLdoUU/omBq9yNezWQ==",
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/domain-service/-/domain-service-1.2.10.tgz",
+      "integrity": "sha512-2VFcikYqzWGq6TJyJocC0UqwReD3qLx4ttk/LOr0z+eM1qHS9v32tGEkEzCNycV7wRs39fUi3xRrhs8RT780GA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ledgerhq/errors": "^6.19.0",
+        "@ledgerhq/errors": "^6.19.1",
         "@ledgerhq/logs": "^6.12.0",
-        "@ledgerhq/types-live": "^6.51.0",
-        "axios": "1.7.3",
+        "@ledgerhq/types-live": "^6.52.4",
+        "axios": "1.7.7",
         "eip55": "^2.1.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       }
     },
-    "node_modules/@ledgerhq/domain-service/node_modules/axios": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
-      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/@ledgerhq/errors": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.19.0.tgz",
-      "integrity": "sha512-c3Jid7euMSnpHFp8H7iPtsmKDjwbTjlG46YKdw+RpCclsqtBx1uQDlYmcbP1Yv9201kVlUFUhhP4H623k8xzlQ==",
+      "version": "6.19.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.19.1.tgz",
+      "integrity": "sha512-75yK7Nnit/Gp7gdrJAz0ipp31CCgncRp+evWt6QawQEtQKYEDfGo10QywgrrBBixeRxwnMy1DP6g2oCWRf1bjw==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -1549,9 +1516,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ledgerhq/types-live": {
-      "version": "6.51.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/types-live/-/types-live-6.51.0.tgz",
-      "integrity": "sha512-iaLIGb0UwXLVIowl//fOlzlN2HTIa7mu8FE1oGZM64mh6kqf7QEguLPhlr3ZaNMmfwCr86oyr6pzNjlcYUHWgg==",
+      "version": "6.52.4",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/types-live/-/types-live-6.52.4.tgz",
+      "integrity": "sha512-cKo+PcGeTxILPeCLdFAu5XiRCPZYDQ6Iz68Y7+fLq13VW8jblpWPHJQybQ2I2gJnzGQle6EPSckfH58qSg6AYA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4843,12 +4810,13 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.1.tgz",
+      "integrity": "sha512-Xd8lFX4LM9QEEwxQpF9J9NTUh8pmdJO0cyRJhFiDoLTk2eH8FXlRv2IFGYVadZpqI3j8fhNrSdKCeYPxiAhLXw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
       }
     },
     "node_modules/core-util-is": {
@@ -5299,10 +5267,11 @@
       }
     },
     "node_modules/elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.0.tgz",
+      "integrity": "sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -7730,27 +7699,6 @@
       "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/hardhat/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/has-bigints": {
@@ -11104,25 +11052,27 @@
       "dev": true
     },
     "node_modules/secp256k1": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
-      "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.4.tgz",
+      "integrity": "sha512-6JfvwvjUOn8F/jUoBY2Q1v5WY5XS+rj8qSe0v8Y4ezH4InLgTEeOOPQsRll9OV429Pvo6BCHGavIyJfr3TAhsw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
-        "elliptic": "^6.5.4",
-        "node-addon-api": "^2.0.0",
+        "elliptic": "^6.5.7",
+        "node-addon-api": "^5.0.0",
         "node-gyp-build": "^4.2.0"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/secp256k1/node_modules/node-addon-api": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
-      "dev": true
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -13061,10 +13011,11 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -154,5 +154,10 @@
     "prettier:contracts": "prettier --write --plugin=prettier-plugin-solidity 'contracts/**/*.sol'",
     "slither": "slither .",
     "postinstall": "patch-package"
+  },
+  "overrides": {
+    "ws": "^8.17.1",
+    "elliptic": "^6.6.0",
+    "cookie": "^1.0.1"
   }
 }


### PR DESCRIPTION
- Fixed with `npm audit fix`
    - Hardhat-ledger vulnerability from `@nomicfoundation/ethereumjs-util` that has `secp256k1` vulnerability.
    └─┬ @nomicfoundation/hardhat-ledger@1.0.3
      └─┬ @nomicfoundation/ethereumjs-util@9.0.4
        └─┬ ethereum-cryptography@0.1.3
          └── secp256k1@4.0.3

    - Hardhat-ledger vulnerability from `@ledgerhq/hw-app-eth` that has `axios` vulnerability
    ├─┬ @nomicfoundation/hardhat-ledger@1.0.3
    │ └─┬ @ledgerhq/hw-app-eth@6.33.6
    │   ├─┬ @ledgerhq/domain-service@1.2.4
    │   │ └── axios@1.7.3
- Fixed thought `overrides` in `package.json` due to vulnerabilities not fixed yet in latest versions of the packages.
    - Circomlibjs latest version vulnerability from `ethers` dependency that has `elliptic` vulnerability that is already reported in issue https://github.com/ethers-io/ethers.js/issues/4878 
    ├─┬ circomlibjs@0.1.7
    │ └─┬ ethers@5.7.2
    │   └─┬ @ethersproject/signing-key@5.7.0
    │     └── elliptic@6.5.4
    
    - Circomlibjs latest version vulnerability from `ethers` dependency that has `ws` vulnerability that is already reported in issue https://github.com/ethers-io/ethers.js/issues/4791
    ├─┬ circomlibjs@0.1.7
    │ └─┬ ethers@5.7.2
    │   └─┬ @ethersproject/providers@5.7.2
    │     └── ws@7.4.6
    
    - Hardhat vulnerability from `cookie` dependency also present in latest hardhat version
    └─┬ hardhat@2.22.10
      └─┬ @sentry/node@5.30.0
        └── cookie@0.4.2

