### PR TITLE
Smart contracts tests speed up

### DIFF
--- a/test/IdentityTreeStore/IdentityTreeStore.test.ts
+++ b/test/IdentityTreeStore/IdentityTreeStore.test.ts
@@ -3,18 +3,26 @@ import { poseidon } from "@iden3/js-crypto";
 import { DeployHelper } from "../../helpers/DeployHelper";
 import { Contract } from "ethers";
 import { publishStateWithStubProof } from "../utils/state-utils";
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
 
 const verifierStubName = "Groth16VerifierStub";
 
 describe("IdentityTreeStore", function () {
   let identityTreeStore, stateContract: Contract;
 
-  beforeEach(async function () {
+  async function deployContractsFixture() {
     const deployHelper = await DeployHelper.initialize();
-    ({ state: stateContract } = await deployHelper.deployStateWithLibraries(["0x0100"], verifierStubName));
+    ({ state: stateContract } = await deployHelper.deployStateWithLibraries(
+      ["0x0100"],
+      verifierStubName,
+    ));
     ({ identityTreeStore } = await deployHelper.deployIdentityTreeStore(
       await stateContract.getAddress(),
     ));
+  }
+
+  beforeEach(async function () {
+    await loadFixture(deployContractsFixture);
   });
 
   it("Should return the revocation status single leaf", async function () {
@@ -31,7 +39,7 @@ describe("IdentityTreeStore", function () {
     const revStatusByState = await identityTreeStore.getRevocationStatusByIdAndState(
       id,
       state,
-      nonce
+      nonce,
     );
 
     const stateTransitionArgs = {
@@ -196,7 +204,7 @@ describe("IdentityTreeStore", function () {
       const revStatusByState = await identityTreeStore.getRevocationStatusByIdAndState(
         id,
         state,
-        nonce
+        nonce,
       );
 
       const stateTransitionArgs = {
@@ -286,7 +294,7 @@ describe("IdentityTreeStore", function () {
     await publishStateWithStubProof(stateContract, stateTransitionArgs);
 
     await expect(
-      identityTreeStore.getRevocationStatusByIdAndState(id, state, nonce)
+      identityTreeStore.getRevocationStatusByIdAndState(id, state, nonce),
     ).to.be.rejectedWith("Invalid state node");
 
     await expect(identityTreeStore.getRevocationStatus(id, nonce)).to.be.rejectedWith(

--- a/test/cross-chain/cross-chain-proof-validator.test.ts
+++ b/test/cross-chain/cross-chain-proof-validator.test.ts
@@ -8,15 +8,20 @@ import { expect } from "chai";
 import { DeployHelper } from "../../helpers/DeployHelper";
 import { Contract } from "ethers";
 import { ethers } from "hardhat";
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
 
 describe("State Cross Chain", function () {
   let crossChainProofValidator: Contract;
   let signer;
 
-  beforeEach(async function () {
+  async function deployContractsFixture() {
     [signer] = await ethers.getSigners();
     const deployHelper = await DeployHelper.initialize(null, true);
     crossChainProofValidator = await deployHelper.deployCrossChainProofValidator();
+  }
+
+  beforeEach(async function () {
+    await loadFixture(deployContractsFixture);
   });
 
   it("Should process the messages without replacedAtTimestamp", async function () {

--- a/test/payment/mc-payment.test.ts
+++ b/test/payment/mc-payment.test.ts
@@ -2,6 +2,7 @@ import { ethers, upgrades } from "hardhat";
 import { MCPayment, MCPayment__factory } from "../../typechain-types";
 import { expect } from "chai";
 import { Signer } from "ethers";
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
 
 describe("MC Payment Contract", () => {
   let payment: MCPayment;
@@ -28,7 +29,7 @@ describe("MC Payment Contract", () => {
     ],
   };
 
-  beforeEach(async () => {
+  async function deployContractsFixture() {
     const signers = await ethers.getSigners();
     issuer1Signer = signers[1];
     userSigner = signers[5];
@@ -39,6 +40,10 @@ describe("MC Payment Contract", () => {
       ownerPercentage,
     ])) as unknown as MCPayment;
     await payment.waitForDeployment();
+  }
+
+  beforeEach(async () => {
+    await loadFixture(deployContractsFixture);
 
     domainData = {
       name: "MCPayment",

--- a/test/payment/vc-payment.test.ts
+++ b/test/payment/vc-payment.test.ts
@@ -4,6 +4,7 @@ import { ethers, upgrades } from "hardhat";
 import { VCPayment, VCPayment__factory } from "../../typechain-types";
 import { expect } from "chai";
 import { Signer } from "ethers";
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
 
 describe("VC Payment Contract", () => {
   let payment: VCPayment;
@@ -19,13 +20,8 @@ describe("VC Payment Contract", () => {
 
   let issuer1Signer, issuer2Signer, owner, userSigner: Signer;
 
-  beforeEach(async () => {
+  async function deployContractsFixture() {
     const ownerPercentage = 5;
-    const signers = await ethers.getSigners();
-    issuer1Signer = signers[1];
-    issuer2Signer = signers[2];
-    userSigner = signers[5];
-    owner = signers[0];
 
     payment = (await upgrades.deployProxy(new VCPayment__factory(owner), [
       await owner.getAddress(),
@@ -53,6 +49,16 @@ describe("VC Payment Contract", () => {
       ownerPercentage,
       issuer2Signer.address,
     );
+  }
+
+  beforeEach(async () => {
+    const signers = await ethers.getSigners();
+    issuer1Signer = signers[1];
+    issuer2Signer = signers[2];
+    userSigner = signers[5];
+    owner = signers[0];
+
+    await loadFixture(deployContractsFixture);
   });
 
   it("Payment and issuer withdraw:", async () => {

--- a/test/smtLib/smtLib.test.ts
+++ b/test/smtLib/smtLib.test.ts
@@ -4,6 +4,7 @@ import hre from "hardhat";
 import { addLeaf, FixedArray, genMaxBinaryNumber, MtpProof } from "../utils/state-utils";
 import { DeployHelper } from "../../helpers/DeployHelper";
 import { Contract } from "ethers";
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
 
 type ParamsProofByHistoricalRoot = {
   index: number | bigint | string;
@@ -45,9 +46,13 @@ type TestCaseRootHistory = {
 describe("Merkle tree proofs of SMT", () => {
   let smt;
 
-  beforeEach(async () => {
+  async function deployContractsFixture() {
     const deployHelper = await DeployHelper.initialize();
     smt = await deployHelper.deploySmtLibTestWrapper();
+  }
+
+  beforeEach(async () => {
+    await loadFixture(deployContractsFixture);
   });
 
   describe("SMT existence proof", () => {
@@ -1065,7 +1070,7 @@ describe("Root history requests", function () {
 
   it("should revert if out of bounds", async () => {
     await expect(smt.getRootHistory(historyLength, 100)).to.be.rejectedWith(
-      "Start index out of bounds"
+      "Start index out of bounds",
     );
   });
 
@@ -1080,9 +1085,13 @@ describe("Root history requests", function () {
 describe("Root history duplicates", function () {
   let smt;
 
-  beforeEach(async () => {
+  async function deployContractsFixture() {
     const deployHelper = await DeployHelper.initialize();
     smt = await deployHelper.deploySmtLibTestWrapper();
+  }
+
+  beforeEach(async () => {
+    await loadFixture(deployContractsFixture);
   });
 
   it("comprehensive check", async () => {
@@ -1117,7 +1126,7 @@ describe("Root history duplicates", function () {
     const riDoubleRoot = await smt.getRootInfoListByRoot(doubleRoot, 0, 100);
     const riTripleRoot = await smt.getRootInfoListByRoot(tripleRoot, 0, 100);
     await expect(smt.getRootInfoListByRoot(nonExistingRoot, 0, 100)).to.be.rejectedWith(
-      "Root does not exist"
+      "Root does not exist",
     );
 
     expect(riSingleRoot.length).to.be.equal(1);
@@ -1149,7 +1158,7 @@ describe("Root history duplicates", function () {
     await smt.add(1, 1);
     const root = await smt.getRoot();
     await expect(smt.getRootInfoListByRoot(root, 0, 0)).to.be.rejectedWith(
-      "Length should be greater than 0"
+      "Length should be greater than 0",
     );
   });
 
@@ -1157,7 +1166,7 @@ describe("Root history duplicates", function () {
     await smt.add(1, 1);
     const root = await smt.getRoot();
     await expect(smt.getRootInfoListByRoot(root, 0, 10 ** 6)).to.be.rejectedWith(
-      "Length limit exceeded"
+      "Length limit exceeded",
     );
   });
 
@@ -1167,7 +1176,7 @@ describe("Root history duplicates", function () {
     await smt.add(1, 1);
     const root = await smt.getRoot();
     await expect(smt.getRootInfoListByRoot(root, 3, 100)).to.be.rejectedWith(
-      "Start index out of bounds"
+      "Start index out of bounds",
     );
   });
 
@@ -1216,10 +1225,13 @@ describe("Binary search in SMT root history", () => {
     expect(riByBlock.root).to.equal(tc.expectedRoot);
   }
 
-  beforeEach(async () => {
+  async function deployContractsFixture() {
     const deployHelper = await DeployHelper.initialize();
     binarySearch = await deployHelper.deployBinarySearchTestWrapper();
+  }
 
+  beforeEach(async () => {
+    await loadFixture(deployContractsFixture);
     const { number: latestBlockNumber } = await hre.ethers.provider.getBlock("latest");
     let blocksToMine = 15 - latestBlockNumber;
 
@@ -1629,9 +1641,13 @@ describe("Binary search in SMT root history", () => {
 describe("Binary search in SMT proofs", () => {
   let smt;
 
-  beforeEach(async () => {
+  async function deployContractsFixture() {
     const deployHelper = await DeployHelper.initialize();
     smt = await deployHelper.deploySmtLibTestWrapper();
+  }
+
+  beforeEach(async () => {
+    await loadFixture(deployContractsFixture);
   });
 
   describe("Zero root proofs", () => {
@@ -1740,9 +1756,13 @@ describe("Binary search in SMT proofs", () => {
 describe("Edge cases with exceptions", () => {
   let smt;
 
-  beforeEach(async () => {
+  async function deployContractsFixture() {
     const deployHelper = await DeployHelper.initialize();
     smt = await deployHelper.deploySmtLibTestWrapper();
+  }
+
+  beforeEach(async () => {
+    await loadFixture(deployContractsFixture);
   });
 
   it("getRootInfo() should throw when root does not exist", async () => {
@@ -1821,21 +1841,21 @@ async function checkTestCaseMTPProof(smt: Contract, testCase: TestCaseMTPProof) 
   if (isProofByHistoricalRoot(testCase.paramsToGetProof)) {
     proof = await smt.getProofByRoot(
       testCase.paramsToGetProof.index,
-      testCase.paramsToGetProof.historicalRoot
+      testCase.paramsToGetProof.historicalRoot,
     );
   }
 
   if (isProofByTime(testCase.paramsToGetProof)) {
     proof = await smt.getProofByTime(
       testCase.paramsToGetProof.index,
-      testCase.paramsToGetProof.timestamp
+      testCase.paramsToGetProof.timestamp,
     );
   }
 
   if (isProofByBlock(testCase.paramsToGetProof)) {
     proof = await smt.getProofByBlock(
       testCase.paramsToGetProof.index,
-      testCase.paramsToGetProof.blockNumber
+      testCase.paramsToGetProof.blockNumber,
     );
   }
 

--- a/test/validators/mtp/index.ts
+++ b/test/validators/mtp/index.ts
@@ -4,6 +4,7 @@ import { DeployHelper } from "../../../helpers/DeployHelper";
 import { packValidatorParams } from "../../utils/validator-pack-utils";
 import { CircuitId } from "@0xpolygonid/js-sdk";
 import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
 
 const tenYears = 315360000;
 const testCases: any[] = [
@@ -128,7 +129,7 @@ describe("Atomic MTP Validator", function () {
         if (test.stateTransitionDelayMs) {
           await Promise.all([
             publishState(state, test.stateTransitions[i]),
-            delay(test.stateTransitionDelayMs),
+            time.increase(test.stateTransitionDelayMs),
           ]);
         } else {
           await publishState(state, test.stateTransitions[i]);

--- a/test/validators/mtp/index.ts
+++ b/test/validators/mtp/index.ts
@@ -127,13 +127,9 @@ describe("Atomic MTP Validator", function () {
       this.timeout(50000);
       for (let i = 0; i < test.stateTransitions.length; i++) {
         if (test.stateTransitionDelayMs) {
-          await Promise.all([
-            publishState(state, test.stateTransitions[i]),
-            time.increase(test.stateTransitionDelayMs),
-          ]);
-        } else {
-          await publishState(state, test.stateTransitions[i]);
+          await time.increase(test.stateTransitionDelayMs);
         }
+        await publishState(state, test.stateTransitions[i]);
       }
 
       const query = {

--- a/test/validators/sig/index.ts
+++ b/test/validators/sig/index.ts
@@ -3,6 +3,7 @@ import { prepareInputs, publishState } from "../../utils/state-utils";
 import { DeployHelper } from "../../../helpers/DeployHelper";
 import { packValidatorParams } from "../../utils/validator-pack-utils";
 import { CircuitId } from "@0xpolygonid/js-sdk";
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
 
 const tenYears = 315360000;
 const testCases: any[] = [
@@ -91,20 +92,33 @@ function delay(ms: number) {
 }
 
 describe("Atomic Sig Validator", function () {
-  let state: any, sig: any;
+  let state: any, sigValidator: any;
   let senderAddress: string;
 
-  beforeEach(async () => {
+  async function deployContractsFixture() {
     senderAddress = "0x3930000000000000000000000000000000000000"; // because challenge is 12345 in proofs.
     const deployHelper = await DeployHelper.initialize(null, true);
 
     const { state: stateContract } = await deployHelper.deployStateWithLibraries(["0x0100"]);
-    state = stateContract;
     const contracts = await deployHelper.deployValidatorContractsWithVerifiers(
       "sigV2",
-      await state.getAddress(),
+      await stateContract.getAddress(),
     );
-    sig = contracts.validator;
+    const validator = contracts.validator;
+
+    return {
+      stateContract,
+      validator,
+      senderAddress,
+    };
+  }
+
+  beforeEach(async () => {
+    ({
+      stateContract: state,
+      validator: sigValidator,
+      senderAddress,
+    } = await loadFixture(deployContractsFixture));
   });
 
   for (const test of testCases) {
@@ -139,17 +153,17 @@ describe("Atomic Sig Validator", function () {
 
       const { inputs, pi_a, pi_b, pi_c } = prepareInputs(test.proofJson);
       if (test.setProofExpiration) {
-        await sig.setProofExpirationTimeout(test.setProofExpiration);
+        await sigValidator.setProofExpirationTimeout(test.setProofExpiration);
       }
       if (test.setRevStateExpiration) {
-        await sig.setRevocationStateExpirationTimeout(test.setRevStateExpiration);
+        await sigValidator.setRevocationStateExpirationTimeout(test.setRevStateExpiration);
       }
       if (test.setGISTRootExpiration) {
-        await sig.setGISTRootExpirationTimeout(test.setGISTRootExpiration);
+        await sigValidator.setGISTRootExpirationTimeout(test.setGISTRootExpiration);
       }
       if (test.errorMessage) {
         await expect(
-          sig.verify(
+          sigValidator.verify(
             inputs,
             pi_a,
             pi_b,
@@ -160,7 +174,7 @@ describe("Atomic Sig Validator", function () {
         ).to.be.rejectedWith(test.errorMessage);
       } else if (test.errorMessage === "") {
         await expect(
-          sig.verify(
+          sigValidator.verify(
             inputs,
             pi_a,
             pi_b,
@@ -170,7 +184,7 @@ describe("Atomic Sig Validator", function () {
           ),
         ).to.be.reverted;
       } else {
-        await sig.verify(
+        await sigValidator.verify(
           inputs,
           pi_a,
           pi_b,
@@ -183,7 +197,7 @@ describe("Atomic Sig Validator", function () {
   }
 
   it("check inputIndexOf", async () => {
-    const challengeIndx = await sig.inputIndexOf("challenge");
+    const challengeIndx = await sigValidator.inputIndexOf("challenge");
     expect(challengeIndx).to.be.equal(5);
   });
 });

--- a/test/validators/sig/index.ts
+++ b/test/validators/sig/index.ts
@@ -4,6 +4,7 @@ import { DeployHelper } from "../../../helpers/DeployHelper";
 import { packValidatorParams } from "../../utils/validator-pack-utils";
 import { CircuitId } from "@0xpolygonid/js-sdk";
 import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
 
 const tenYears = 315360000;
 const testCases: any[] = [
@@ -128,7 +129,7 @@ describe("Atomic Sig Validator", function () {
         if (test.stateTransitionDelayMs) {
           await Promise.all([
             publishState(state, test.stateTransitions[i]),
-            delay(test.stateTransitionDelayMs),
+            time.increase(test.stateTransitionDelayMs),
           ]);
         } else {
           await publishState(state, test.stateTransitions[i]);

--- a/test/validators/sig/index.ts
+++ b/test/validators/sig/index.ts
@@ -127,13 +127,9 @@ describe("Atomic Sig Validator", function () {
       this.timeout(50000);
       for (let i = 0; i < test.stateTransitions.length; i++) {
         if (test.stateTransitionDelayMs) {
-          await Promise.all([
-            publishState(state, test.stateTransitions[i]),
-            time.increase(test.stateTransitionDelayMs),
-          ]);
-        } else {
-          await publishState(state, test.stateTransitions[i]);
+          await time.increase(test.stateTransitionDelayMs);
         }
+        await publishState(state, test.stateTransitions[i]);
       }
 
       const query = {

--- a/test/validators/v3/index.ts
+++ b/test/validators/v3/index.ts
@@ -357,13 +357,9 @@ describe("Atomic V3 Validator", function () {
       this.timeout(50000);
       for (let i = 0; i < test.stateTransitions.length; i++) {
         if (test.stateTransitionDelayMs) {
-          await Promise.all([
-            publishState(state, test.stateTransitions[i]),
-            time.increase(test.stateTransitionDelayMs),
-          ]);
-        } else {
-          await publishState(state, test.stateTransitions[i]);
+          await time.increase(test.stateTransitionDelayMs);
         }
+        await publishState(state, test.stateTransitions[i]);
       }
 
       const value = ["20010101", ...new Array(63).fill("0")];

--- a/test/validators/v3/index.ts
+++ b/test/validators/v3/index.ts
@@ -4,6 +4,7 @@ import { DeployHelper } from "../../../helpers/DeployHelper";
 import { packV3ValidatorParams } from "../../utils/validator-pack-utils";
 import { calculateQueryHashV3 } from "../../utils/query-hash-utils";
 import { CircuitId } from "@0xpolygonid/js-sdk";
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
 
 const tenYears = 315360000;
 const testCases: any[] = [
@@ -329,17 +330,25 @@ function delay(ms: number) {
 describe("Atomic V3 Validator", function () {
   let state: any, v3validator;
 
-  beforeEach(async () => {
+  async function deployContractsFixture() {
     const deployHelper = await DeployHelper.initialize(null, true);
 
     const { state: stateContract } = await deployHelper.deployStateWithLibraries(["0x0212"]);
-    state = stateContract;
 
     const contracts = await deployHelper.deployValidatorContractsWithVerifiers(
       "v3",
-      await state.getAddress(),
+      await stateContract.getAddress(),
     );
-    v3validator = contracts.validator;
+    const validator = contracts.validator;
+
+    return {
+      stateContract,
+      validator,
+    };
+  }
+
+  beforeEach(async () => {
+    ({ stateContract: state, validator: v3validator } = await loadFixture(deployContractsFixture));
   });
 
   for (const test of testCases) {

--- a/test/validators/v3/index.ts
+++ b/test/validators/v3/index.ts
@@ -5,6 +5,7 @@ import { packV3ValidatorParams } from "../../utils/validator-pack-utils";
 import { calculateQueryHashV3 } from "../../utils/query-hash-utils";
 import { CircuitId } from "@0xpolygonid/js-sdk";
 import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
 
 const tenYears = 315360000;
 const testCases: any[] = [
@@ -358,7 +359,7 @@ describe("Atomic V3 Validator", function () {
         if (test.stateTransitionDelayMs) {
           await Promise.all([
             publishState(state, test.stateTransitions[i]),
-            delay(test.stateTransitionDelayMs),
+            time.increase(test.stateTransitionDelayMs),
           ]);
         } else {
           await publishState(state, test.stateTransitions[i]);

--- a/test/verifier/embedded-zkp-verifier.test.ts
+++ b/test/verifier/embedded-zkp-verifier.test.ts
@@ -7,6 +7,7 @@ import { Block, Signer } from "ethers";
 import { buildCrossChainProofs, packCrossChainProofs, packZKProof } from "../utils/packData";
 import proofJson from "../validators/sig/data/valid_sig_user_genesis.json";
 import { CircuitId } from "@0xpolygonid/js-sdk";
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
 
 describe("Embedded ZKP Verifier", function () {
   let verifier: any, sig: any;
@@ -27,7 +28,7 @@ describe("Embedded ZKP Verifier", function () {
     claimPathNotExists: 0,
   };
 
-  beforeEach(async () => {
+  async function deployContractsFixture() {
     const deployHelper = await DeployHelper.initialize(null, true);
     [owner] = await ethers.getSigners();
 
@@ -43,6 +44,10 @@ describe("Embedded ZKP Verifier", function () {
 
     const stub = await deployHelper.deployValidatorStub();
     sig = stub;
+  }
+
+  beforeEach(async () => {
+    await loadFixture(deployContractsFixture);
   });
 
   it("test submit response", async () => {

--- a/test/verifier/universal-verifier-linked-proofs.test.ts
+++ b/test/verifier/universal-verifier-linked-proofs.test.ts
@@ -4,6 +4,7 @@ import { packV3ValidatorParams } from "../utils/validator-pack-utils";
 import { prepareInputs, publishState } from "../utils/state-utils";
 import { expect } from "chai";
 import testData from "./linked-proofs-data.json";
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
 
 describe("Universal Verifier Linked proofs", function () {
   let verifier: any, v3: any, state: any;
@@ -11,7 +12,7 @@ describe("Universal Verifier Linked proofs", function () {
   let signerAddress: string;
   let deployHelper: DeployHelper;
 
-  beforeEach(async () => {
+  async function deployContractsFixture() {
     [signer, signer2] = await ethers.getSigners();
     signerAddress = await signer.getAddress();
 
@@ -48,6 +49,10 @@ describe("Universal Verifier Linked proofs", function () {
       const { inputs, pi_a, pi_b, pi_c } = prepareInputs(testData.queryData.zkpResponses[i]);
       await verifier.submitZKPResponse(100 + i, inputs, pi_a, pi_b, pi_c);
     }
+  }
+
+  beforeEach(async () => {
+    await loadFixture(deployContractsFixture);
   });
 
   it("should linked proof validation pass", async () => {

--- a/test/verifier/universal-verifier-submit-V2.test.ts
+++ b/test/verifier/universal-verifier-submit-V2.test.ts
@@ -7,6 +7,7 @@ import { Block, Contract } from "ethers";
 import proofJson from "../validators/sig/data/valid_sig_user_genesis.json";
 import { buildCrossChainProofs, packCrossChainProofs, packZKProof } from "../utils/packData";
 import { CircuitId } from "@0xpolygonid/js-sdk";
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
 
 describe("Universal Verifier V2 MTP & SIG validators", function () {
   let verifier: any, sig: any;
@@ -51,7 +52,7 @@ describe("Universal Verifier V2 MTP & SIG validators", function () {
     claimPathNotExists: 0,
   };
 
-  beforeEach(async () => {
+  async function deployContractsFixture() {
     [signer] = await ethers.getSigners();
     signerAddress = await signer.getAddress();
 
@@ -75,6 +76,10 @@ describe("Universal Verifier V2 MTP & SIG validators", function () {
     sig = validatorStub;
     await verifier.addValidatorToWhitelist(await sig.getAddress());
     await verifier.connect();
+  }
+
+  beforeEach(async () => {
+    await loadFixture(deployContractsFixture);
   });
 
   it("Test submit response V2", async () => {

--- a/test/verifier/universal-verifier.events.test.ts
+++ b/test/verifier/universal-verifier.events.test.ts
@@ -117,8 +117,7 @@ describe("Universal Verifier events", function () {
 
     const coder = AbiCoder.defaultAbiCoder();
     logs.map((log, index) => {
-      // @ts-ignore
-      const [decodedData] = coder.decode(abi, log.args.data);
+      const [decodedData] = coder.decode(abi as any, log.args.data);
       expect(decodedData.schema).to.equal(queries[index].schema);
       expect(decodedData.claimPathKey).to.equal(queries[index].claimPathKey);
       expect(decodedData.operator).to.equal(queries[index].operator);

--- a/test/verifier/universal-verifier.test.ts
+++ b/test/verifier/universal-verifier.test.ts
@@ -6,9 +6,10 @@ import { prepareInputs } from "../utils/state-utils";
 import { Block } from "ethers";
 import proofJson from "../validators/mtp/data/valid_mtp_user_genesis.json";
 import { CircuitId } from "@0xpolygonid/js-sdk";
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
 
 describe("Universal Verifier MTP & SIG validators", function () {
-  let verifier: any, sig: any, state: any;
+  let verifier: any, sigValidator: any, state: any;
   let signer, signer2, signer3;
   let signerAddress: string;
   let deployHelper: DeployHelper;
@@ -28,25 +29,38 @@ describe("Universal Verifier MTP & SIG validators", function () {
     claimPathNotExists: 0,
   };
 
-  beforeEach(async () => {
-    [signer, signer2, signer3] = await ethers.getSigners();
-    signerAddress = await signer.getAddress();
+  async function deployContractsFixture() {
+    const [ethSigner, ethSigner2, ethSigner3] = await ethers.getSigners();
 
     deployHelper = await DeployHelper.initialize(null, true);
-    ({ state } = await deployHelper.deployStateWithLibraries(["0x0112"]));
+    const { state: stateContract } = await deployHelper.deployStateWithLibraries(["0x0112"]);
     const verifierLib = await deployHelper.deployVerifierLib();
 
-    verifier = await deployHelper.deployUniversalVerifier(
-      signer,
-      await state.getAddress(),
+    const universalVerifier: any = await deployHelper.deployUniversalVerifier(
+      ethSigner,
+      await stateContract.getAddress(),
       await verifierLib.getAddress(),
     );
 
     const stub = await deployHelper.deployValidatorStub();
 
-    sig = stub;
-    await verifier.addValidatorToWhitelist(await sig.getAddress());
-    await verifier.connect();
+    const validator = stub;
+    await universalVerifier.addValidatorToWhitelist(await validator.getAddress());
+    await universalVerifier.connect();
+
+    return { ethSigner, ethSigner2, ethSigner3, stateContract, universalVerifier, validator };
+  }
+
+  beforeEach(async () => {
+    ({
+      ethSigner: signer,
+      ethSigner2: signer2,
+      ethSigner3: signer3,
+      stateContract: state,
+      universalVerifier: verifier,
+      validator: sigValidator,
+    } = await loadFixture(deployContractsFixture));
+    signerAddress = await signer.getAddress();
   });
 
   it("Test get state address", async () => {
@@ -56,7 +70,7 @@ describe("Universal Verifier MTP & SIG validators", function () {
 
   it("Test add, get ZKPRequest, requestIdExists, getZKPRequestsCount", async () => {
     const requestsCount = 3;
-    const validatorAddr = await sig.getAddress();
+    const validatorAddr = await sigValidator.getAddress();
 
     for (let i = 0; i < requestsCount; i++) {
       await expect(
@@ -92,7 +106,7 @@ describe("Universal Verifier MTP & SIG validators", function () {
 
     await verifier.setZKPRequest(0, {
       metadata: "metadata",
-      validator: await sig.getAddress(),
+      validator: await sigValidator.getAddress(),
       data: data,
     });
 
@@ -136,7 +150,7 @@ describe("Universal Verifier MTP & SIG validators", function () {
     for (let i = 0; i < 30; i++) {
       await verifier.setZKPRequest(i, {
         metadata: "metadataN" + i,
-        validator: await sig.getAddress(),
+        validator: await sigValidator.getAddress(),
         data: "0x00",
       });
     }
@@ -166,7 +180,7 @@ describe("Universal Verifier MTP & SIG validators", function () {
     );
     await verifier.connect(requestOwner).setZKPRequest(requestId, {
       metadata: "metadata",
-      validator: await sig.getAddress(),
+      validator: await sigValidator.getAddress(),
       data: packValidatorParams(query),
     });
 
@@ -205,7 +219,7 @@ describe("Universal Verifier MTP & SIG validators", function () {
 
     await verifier.connect(requestOwner).setZKPRequest(requestId, {
       metadata: "metadata",
-      validator: await sig.getAddress(),
+      validator: await sigValidator.getAddress(),
       data: packValidatorParams(query),
     });
     expect(await verifier.isZKPRequestEnabled(requestId)).to.be.true;
@@ -258,7 +272,6 @@ describe("Universal Verifier MTP & SIG validators", function () {
     const someAddress = signer2;
     const requestId = 1;
     const otherRequestId = 2;
-    const { state } = await deployHelper.deployStateWithLibraries();
     const { validator: mtp } = await deployHelper.deployValidatorContractsWithVerifiers(
       "mtpV2",
       await state.getAddress(),


### PR DESCRIPTION
Speed up smart contracts tests:
- Use of hardhat `fixtures` for avoiding deployment of contracts in each test in the same test script
```
import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
```
- Use `time` helper for increasing blockchain time in validators tests instead of waiting explicitly in script
```
import { time } from "@nomicfoundation/hardhat-network-helpers";
```
