### PR TITLE
Fix upgrade universal verifier 

### DIFF
--- a/helpers/UniversalVerifierContractMigrationHelper.ts
+++ b/helpers/UniversalVerifierContractMigrationHelper.ts
@@ -16,9 +16,18 @@ export class UniversalVerifierContractMigrationHelper extends ContractMigrationS
   @log
   async getDataFromContract(contract: Contract, ...args: any[]): Promise<any> {
     const countRequests = await contract.getZKPRequestsCount();
+    const stateAddress = await contract.getStateAddress();
 
+    const result = { countRequests, stateAddress };
+    return result;
+  }
+
+  @log
+  async getDataFirstRequestFromContract(contract: Contract): Promise<any> {
     let validator: string = "";
     let request: any = {};
+
+    const countRequests = await contract.getZKPRequestsCount();
 
     if (countRequests > 0) {
       const filter = contract.filters.ZKPRequestSet;
@@ -64,11 +73,10 @@ export class UniversalVerifierContractMigrationHelper extends ContractMigrationS
     const result1 = args[0];
     const result2 = args[1];
 
-    const { request: requestV1, countRequests: countRequestsV1, validator: validatorV1 } = result1;
-    const { request: requestV2, countRequests: countRequestsV2, validator: validatorV2 } = result2;
+    const { countRequests: countRequestsV1, stateAddress: stateAddress1 } = result1;
+    const { countRequests: countRequestsV2, stateAddress: stateAddress2 } = result2;
     console.assert(countRequestsV1 === countRequestsV2, "lenght of requests not equal");
-    console.assert(JSON.stringify(requestV1) === JSON.stringify(requestV2), "requests not equal");
-    console.assert(validatorV1 === validatorV2, "validator not equal");
+    console.assert(stateAddress1 === stateAddress2, "state address not equal");
   }
 
   @log

--- a/scripts/upgrade/validators/validators-upgrade.ts
+++ b/scripts/upgrade/validators/validators-upgrade.ts
@@ -65,12 +65,12 @@ async function main() {
       validatorVerification: contractsInfo.VALIDATOR_V3.verificationOpts,
       version: contractsInfo.VALIDATOR_V3.version,
     },
-    {
-      validatorContractAddress: contractsInfo.VALIDATOR_AUTH_V2.unifiedAddress,
-      validatorContractName: contractsInfo.VALIDATOR_AUTH_V2.name,
-      validatorType: VALIDATOR_TYPES.V3,
-      validatorVerification: contractsInfo.VALIDATOR_AUTH_V2.verificationOpts,
-    },
+    // {
+    //   validatorContractAddress: contractsInfo.VALIDATOR_AUTH_V2.unifiedAddress,
+    //   validatorContractName: contractsInfo.VALIDATOR_AUTH_V2.name,
+    //   validatorType: VALIDATOR_TYPES.V3,
+    //   validatorVerification: contractsInfo.VALIDATOR_AUTH_V2.verificationOpts,
+    // },
   ];
 
   const validatorsInfo: any = [];

--- a/scripts/upgrade/validators/validators-upgrade.ts
+++ b/scripts/upgrade/validators/validators-upgrade.ts
@@ -68,7 +68,7 @@ async function main() {
     // {
     //   validatorContractAddress: contractsInfo.VALIDATOR_AUTH_V2.unifiedAddress,
     //   validatorContractName: contractsInfo.VALIDATOR_AUTH_V2.name,
-    //   validatorType: VALIDATOR_TYPES.V3,
+    //   validatorType: VALIDATOR_TYPES.AUTH_V2,
     //   validatorVerification: contractsInfo.VALIDATOR_AUTH_V2.verificationOpts,
     // },
   ];

--- a/scripts/upgrade/verifiers/universal-verifier-upgrade.ts
+++ b/scripts/upgrade/verifiers/universal-verifier-upgrade.ts
@@ -111,7 +111,11 @@ async function main() {
   const dataBeforeUpgrade =
     await universalVerifierMigrationHelper.getDataFromContract(universalVerifierContract);
 
-  const whitelistedValidators = dataBeforeUpgrade.validators;
+  const whitelistedValidators = [
+    contractsInfo.VALIDATOR_MTP.unifiedAddress,
+    contractsInfo.VALIDATOR_SIG.unifiedAddress,
+    contractsInfo.VALIDATOR_V3.unifiedAddress,
+  ];
 
   for (const validator of whitelistedValidators) {
     expect(await universalVerifierContract.isWhitelistedValidator(validator)).to.equal(true);


### PR DESCRIPTION
- Fix error in ` getDataFromContract` when upgrading Universal Verifier
- Data from first request removed from upgrade check and created in separate function for future review
- Get requests count and state address that is enough to check storage before and after upgrade