### PR TITLE
Add setZKPRequests for multiple set of zkp requests

### DIFF
--- a/contracts/interfaces/IZKPVerifier.sol
+++ b/contracts/interfaces/IZKPVerifier.sol
@@ -79,6 +79,13 @@ interface IZKPVerifier {
     function setZKPRequest(uint64 requestId, ZKPRequest calldata request) external;
 
     /**
+     * @dev Set the list of ZKP requests for the list of requestIds in the same order.
+     * @param requestIds Request ids of the ZKP requests.
+     * @param requests ZKP requests to set.
+     */
+    function setZKPRequests(uint64[] calldata requestIds, ZKPRequest[] calldata requests) external;
+
+    /**
      * @dev Get the ZKP request for the requestId.
      * @param requestId Request id of the ZKP request.
      * @return ZKP request.

--- a/contracts/interfaces/IZKPVerifier.sol
+++ b/contracts/interfaces/IZKPVerifier.sol
@@ -79,13 +79,6 @@ interface IZKPVerifier {
     function setZKPRequest(uint64 requestId, ZKPRequest calldata request) external;
 
     /**
-     * @dev Set the list of ZKP requests for the list of requestIds in the same order.
-     * @param requestIds Request ids of the ZKP requests.
-     * @param requests ZKP requests to set.
-     */
-    function setZKPRequests(uint64[] calldata requestIds, ZKPRequest[] calldata requests) external;
-
-    /**
      * @dev Get the ZKP request for the requestId.
      * @param requestId Request id of the ZKP request.
      * @return ZKP request.

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@iden3/contracts",
   "description": "Smart Contract library for Solidity",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "files": [
     "**/*.sol",
     "/build/contracts/*.json",

--- a/contracts/verifiers/EmbeddedZKPVerifier.sol
+++ b/contracts/verifiers/EmbeddedZKPVerifier.sol
@@ -40,6 +40,18 @@ abstract contract EmbeddedZKPVerifier is Ownable2StepUpgradeable, ZKPVerifierBas
         super.setZKPRequest(requestId, request);
     }
 
+    /**
+     * @dev Set the list of ZKP requests for the list of requestIds in the same order.
+     * @param requestIds Request ids of the ZKP requests.
+     * @param requests ZKP requests to set.
+     */
+    function setZKPRequests(
+        uint64[] calldata requestIds,
+        ZKPRequest[] calldata requests
+    ) public virtual override onlyOwner {
+        super.setZKPRequests(requestIds, requests);
+    }
+
     /// @dev Submits a ZKP response and updates proof status
     /// @param requestId The ID of the ZKP request
     /// @param inputs The input data for the proof

--- a/contracts/verifiers/RequestOwnership.sol
+++ b/contracts/verifiers/RequestOwnership.sol
@@ -46,7 +46,10 @@ abstract contract RequestOwnership is ZKPVerifierBase {
      * @param requestIds Request ids of the ZKP requests.
      * @param requests ZKP requests to set.
      */
-    function setZKPRequests(uint64[] calldata requestIds, ZKPRequest[] calldata requests) public virtual override {
+    function setZKPRequests(
+        uint64[] calldata requestIds,
+        ZKPRequest[] calldata requests
+    ) public virtual override {
         for (uint256 i = 0; i < requestIds.length; i++) {
             setZKPRequest(requestIds[i], requests[i]);
         }

--- a/contracts/verifiers/RequestOwnership.sol
+++ b/contracts/verifiers/RequestOwnership.sol
@@ -41,6 +41,17 @@ abstract contract RequestOwnership is ZKPVerifierBase {
         _setRequestOwner(requestId, _msgSender());
     }
 
+    /**
+     * @dev Set the list of ZKP requests for the list of requestIds in the same order.
+     * @param requestIds Request ids of the ZKP requests.
+     * @param requests ZKP requests to set.
+     */
+    function setZKPRequests(uint64[] calldata requestIds, ZKPRequest[] calldata requests) public virtual override {
+        for (uint256 i = 0; i < requestIds.length; i++) {
+            setZKPRequest(requestIds[i], requests[i]);
+        }
+    }
+
     /// @dev Get a ZKP Request Owner address
     /// @param requestId The ID of a ZKP Request
     /// @return The ZKP Request Owner address

--- a/contracts/verifiers/UniversalVerifier.sol
+++ b/contracts/verifiers/UniversalVerifier.sol
@@ -21,7 +21,7 @@ contract UniversalVerifier is
     /**
      * @dev Version of contract
      */
-    string public constant VERSION = "1.1.4";
+    string public constant VERSION = "1.1.5";
 
     /// @dev Event emitted upon submitting a ZKP request
     event ZKPResponseSubmitted(uint64 indexed requestId, address indexed caller);

--- a/contracts/verifiers/UniversalVerifier.sol
+++ b/contracts/verifiers/UniversalVerifier.sol
@@ -83,6 +83,17 @@ contract UniversalVerifier is
         );
     }
 
+    /**
+     * @dev Set the list of ZKP requests for the list of requestIds in the same order.
+     * @param requestIds Request ids of the ZKP requests.
+     * @param requests ZKP requests to set.
+     */
+    function setZKPRequests(uint64[] calldata requestIds, ZKPRequest[] calldata requests) public override(RequestOwnership, ValidatorWhitelist, ZKPVerifierBase) {
+        for (uint256 i = 0; i < requestIds.length; i++) {
+            setZKPRequest(requestIds[i], requests[i]);
+        }
+    }
+
     /// @dev Update a ZKP request
     /// @param requestId The ID of the ZKP request
     /// @param request The ZKP request data

--- a/contracts/verifiers/UniversalVerifier.sol
+++ b/contracts/verifiers/UniversalVerifier.sol
@@ -88,7 +88,10 @@ contract UniversalVerifier is
      * @param requestIds Request ids of the ZKP requests.
      * @param requests ZKP requests to set.
      */
-    function setZKPRequests(uint64[] calldata requestIds, ZKPRequest[] calldata requests) public override(RequestOwnership, ValidatorWhitelist, ZKPVerifierBase) {
+    function setZKPRequests(
+        uint64[] calldata requestIds,
+        ZKPRequest[] calldata requests
+    ) public override(RequestOwnership, ValidatorWhitelist, ZKPVerifierBase) {
         for (uint256 i = 0; i < requestIds.length; i++) {
             setZKPRequest(requestIds[i], requests[i]);
         }

--- a/contracts/verifiers/ValidatorWhitelist.sol
+++ b/contracts/verifiers/ValidatorWhitelist.sol
@@ -42,6 +42,17 @@ contract ValidatorWhitelist is ZKPVerifierBase {
         super.setZKPRequest(requestId, request);
     }
 
+    /**
+     * @dev Set the list of ZKP requests for the list of requestIds in the same order.
+     * @param requestIds Request ids of the ZKP requests.
+     * @param requests ZKP requests to set.
+     */
+    function setZKPRequests(uint64[] calldata requestIds, ZKPRequest[] calldata requests) public virtual override {
+        for (uint256 i = 0; i < requestIds.length; i++) {
+            setZKPRequest(requestIds[i], requests[i]);
+        }
+    }
+    
     /// @dev Verifies a ZKP response without updating any proof status
     /// @param requestId The ID of the ZKP request
     /// @param inputs The public inputs for the proof

--- a/contracts/verifiers/ValidatorWhitelist.sol
+++ b/contracts/verifiers/ValidatorWhitelist.sol
@@ -47,12 +47,15 @@ contract ValidatorWhitelist is ZKPVerifierBase {
      * @param requestIds Request ids of the ZKP requests.
      * @param requests ZKP requests to set.
      */
-    function setZKPRequests(uint64[] calldata requestIds, ZKPRequest[] calldata requests) public virtual override {
+    function setZKPRequests(
+        uint64[] calldata requestIds,
+        ZKPRequest[] calldata requests
+    ) public virtual override {
         for (uint256 i = 0; i < requestIds.length; i++) {
             setZKPRequest(requestIds[i], requests[i]);
         }
     }
-    
+
     /// @dev Verifies a ZKP response without updating any proof status
     /// @param requestId The ID of the ZKP request
     /// @param inputs The public inputs for the proof

--- a/contracts/verifiers/ZKPVerifierBase.sol
+++ b/contracts/verifiers/ZKPVerifierBase.sol
@@ -86,6 +86,19 @@ abstract contract ZKPVerifierBase is IZKPVerifier, ContextUpgradeable {
         s._requestIds.push(requestId);
     }
 
+    /**
+     * @dev Set the ZKP request for the requestId.
+     * @param requestIds Request ids of the ZKP requests.
+     * @param requests ZKP requests to set.
+     */
+    function setZKPRequests(uint64[] calldata requestIds, ZKPRequest[] calldata requests) public virtual {
+        require(requestIds.length == requests.length, "Request IDs and requests length mismatch");
+
+        for (uint256 i = 0; i < requestIds.length; i++) {
+            setZKPRequest(requestIds[i], requests[i]);
+        }
+    }
+
     /// @notice Submits a ZKP response and updates proof status
     /// @param requestId The ID of the ZKP request
     /// @param inputs The input data for the proof

--- a/contracts/verifiers/ZKPVerifierBase.sol
+++ b/contracts/verifiers/ZKPVerifierBase.sol
@@ -91,7 +91,10 @@ abstract contract ZKPVerifierBase is IZKPVerifier, ContextUpgradeable {
      * @param requestIds Request ids of the ZKP requests.
      * @param requests ZKP requests to set.
      */
-    function setZKPRequests(uint64[] calldata requestIds, ZKPRequest[] calldata requests) public virtual {
+    function setZKPRequests(
+        uint64[] calldata requestIds,
+        ZKPRequest[] calldata requests
+    ) public virtual {
         require(requestIds.length == requests.length, "Request IDs and requests length mismatch");
 
         for (uint256 i = 0; i < requestIds.length; i++) {

--- a/helpers/constants.ts
+++ b/helpers/constants.ts
@@ -108,7 +108,7 @@ export const contractsInfo = Object.freeze({
   },
   UNIVERSAL_VERIFIER: {
     name: "UniversalVerifier",
-    version: "1.1.4",
+    version: "1.1.5",
     unifiedAddress: "0xfcc86A79fCb057A8e55C6B853dff9479C3cf607c",
     create2Calldata: ethers.hexlify(ethers.toUtf8Bytes("iden3.create2.UniversalVerifier")),
     verificationOpts: {

--- a/test/verifier/universal-verifier.test.ts
+++ b/test/verifier/universal-verifier.test.ts
@@ -108,6 +108,39 @@ describe("Universal Verifier MTP & SIG validators", function () {
     expect(count).to.be.equal(requestsCount);
   });
 
+  it("Test add, get ZKPRequest, requestIdExists, getZKPRequestsCount with multiple set", async () => {
+    const requestsCount = 3;
+    const validatorAddr = await validator.getAddress();
+
+    const requestIds: number[] = [];
+    const requests: any[] = [];
+    for (let i = 0; i < requestsCount; i++) {
+      requestIds.push(i);
+      requests.push({
+        metadata: "metadataN" + i,
+        validator: validatorAddr,
+        data: "0x0" + i,
+      });
+    }
+
+    await expect(verifier.setZKPRequests(requestIds, requests))
+      .to.emit(verifier, "ZKPRequestSet")
+      .withArgs(0, signerAddress, "metadataN" + 0, validatorAddr, "0x0" + 0);
+
+    for (let i = 1; i < requestsCount; i++) {
+      const request = await verifier.getZKPRequest(i);
+      expect(request.metadata).to.be.equal("metadataN" + i);
+      expect(request.validator).to.be.equal(validatorAddr);
+      expect(request.data).to.be.equal("0x0" + i);
+
+      const requestIdExists = await verifier.requestIdExists(i);
+      expect(requestIdExists).to.be.true;
+    }
+
+    const count = await verifier.getZKPRequestsCount();
+    expect(count).to.be.equal(requestsCount);
+  });
+
   it("Test submit response", async () => {
     const requestId = 0;
     const nonExistingRequestId = 1;


### PR DESCRIPTION
We need a function for ‘multiple set’, so on query builder one transaction will be created when user choose two or more attributes to query.
