### PR TITLE
fix: Fix incorrect issuer balance check in withdrawal test

### DIFF
--- a/test/payment/vc-payment.test.ts
+++ b/test/payment/vc-payment.test.ts
@@ -148,7 +148,7 @@ describe("VC Payment Contract", () => {
     const issuer1BalanceAfterWithdraw = await payment.connect(issuer1Signer).getMyBalance();
     expect(issuer1BalanceAfterWithdraw).to.be.eq(0);
 
-    const issuer2BalanceAfterWithdraw = await payment.connect(issuer1Signer).getMyBalance();
+    const issuer2BalanceAfterWithdraw = await payment.connect(issuer2Signer).getMyBalance();
     expect(issuer2BalanceAfterWithdraw).to.be.eq(0);
 
     expect(await ethers.provider.getBalance(issuer1Signer.address)).to.be.eq(


### PR DESCRIPTION
I noticed a mistake in the test "Withdraw to all issuers and owner." The current code uses `issuer1Signer` to check the balance of `issuer2`, which is logically incorrect.
This causes the test to verify the balance of `issuer1` instead of `issuer2`, leading to inaccurate results.

i've corrected the signer to ensure the proper balance is checked.  

Here's the fix:  
```javascript  
const issuer2BalanceAfterWithdraw = await payment.connect(issuer2Signer).getMyBalance();  
```  
