### PR TITLE
fix: Use fromMnemonic instead of non-existent fromPhrase

### DIFF
--- a/scripts/maintenance/multi-chain/checkIdTypes.ts
+++ b/scripts/maintenance/multi-chain/checkIdTypes.ts
@@ -7,7 +7,7 @@ import {
 import { contractsInfo, DEFAULT_MNEMONIC, networks } from "../../../helpers/constants";
 import { ethers } from "hardhat";
 
-const mnemonicWallet = ethers.Wallet.fromPhrase(DEFAULT_MNEMONIC);
+const mnemonicWallet = ethers.Wallet.fromMnemonic(DEFAULT_MNEMONIC);
 
 async function main() {
   const providers = getProviders();


### PR DESCRIPTION
### Description
I noticed that the code was using `fromPhrase`, which doesn't exist in the ethers library.
This has been corrected to use `fromMnemonic` for creating a wallet from a mnemonic phrase.

The change ensures compatibility with the library and resolves the issue.