### PR TITLE
Circuits URL Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ COINMARKETCAP_KEY=<<your coinmarketcap key>> REPORT_GAS=true npx hardhat test
 
 ## Circuits needed for some maintenance and upgrade scripts
 For some of the scripts you need to download the zk circuits for generation and verification of the proofs.
-Download the zk circuits into `./scripts/upgrade/verifiers/helpers/circuits` by running `./scripts/upgrade/verifiers/helpers/dl_circuits.sh`. This will download the latest files from `https://iden3-circuits-bucket.s3.eu-west-1.amazonaws.com/latest.zip`
+Download the zk circuits into `./scripts/upgrade/verifiers/helpers/circuits` by running `./scripts/upgrade/verifiers/helpers/dl_circuits.sh`. This will download the latest files from `https://circuits.privado.id/latest.zip`
 
     ```bash
     cd ./scripts/upgrade/verifiers/helpers 

--- a/scripts/upgrade/verifiers/helpers/dl_circuits.sh
+++ b/scripts/upgrade/verifiers/helpers/dl_circuits.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Download the latest.zip file
-curl -LO https://iden3-circuits-bucket.s3.eu-west-1.amazonaws.com/latest.zip
+curl -LO https://circuits.privado.id/latest.zip
 
 # Unzip the file into ./circuits
 unzip -d ./circuits latest.zip


### PR DESCRIPTION
https://iden3-circuits-bucket.s3.eu-west-1.amazonaws.com/latest.zip is not accessible. So, It's replaced with https://circuits.privado.id/latest.zip 
